### PR TITLE
fix: fix regex to properly convert slashes to dashes

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -62,7 +62,7 @@ runs:
           let cacheFrom = [
             "${{ steps.refs.outputs.baseRef }}",
             "${{ steps.refs.outputs.headRef }}",
-          ].map(ref => ref.replaceAll(/[^a-zA-Z0-9/-]+/g, "-"))
+          ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);
           core.setOutput("cacheFrom", cacheFrom);


### PR DESCRIPTION
This PR fixes a cacheing problem where slashes were added to the registry tag. It also now accepts periods and underscores.