### PR TITLE
fix: adding env to list check

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -40,7 +40,7 @@ runs:
 
         echo "Targetting Stack ${STACK_NAME}"
 
-        if $(happy list --aws-profile "" 2>&1 | grep -q ${STACK_NAME} ); then
+        if $(happy list --aws-profile --env=${ENV} "" 2>&1 | grep -q ${STACK_NAME} ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag sha-${GITHUB_SHA} ${STACK_NAME}
         else


### PR DESCRIPTION
This PR adds the env flag to the list check so it properly checks the stack in the right environment.