### PR TITLE
fix: revert "chore: bump google-github-actions/release-please-action from 3.0.0 to 3.2.1"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
 
       - name: release please
-        uses: google-github-actions/release-please-action@v3.2.1
+        uses: google-github-actions/release-please-action@v3.0.0
         id: release
         with:
           release-type: simple


### PR DESCRIPTION
Reverts chanzuckerberg/github-actions#81. That PR seems to be breaking how tags work and is tagging everything the same thing.