### PR TITLE
fix: conventional-commits can match more characters in () identifier

### DIFF
--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/github-script@v5
       with:
         script: |
-          const validator = /^(chore|feat|fix|revert|docs|style)(\([a-z ]+\))?(!)?: (.)+$/
+          const validator = /^(chore|feat|fix|revert|docs|style)(\([a-zA-Z0-9- ]+\))?(!)?: (.)+$/
           const title = context.payload.pull_request.title
           const is_valid = validator.test(title)
 
@@ -17,4 +17,3 @@ runs:
             })
             core.setFailed(`Your pr title doesn't adhere to conventional commits syntax. See more details: ${details}`)
           }
-# bump

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "14"
+        node-version: "18"
         check-latest: true
     - run: npm install csv-parse
       shell: bash
@@ -19,7 +19,7 @@ runs:
           const {parse} = require('csv-parse/sync');
 
           // From https://github.com/docker/metadata-action/blob/b2391d37b4157fa4aa2e118d643f417910ff3242/src/context.ts#L41
-          const getInputList = func(name) {
+          const getInputList = function(name) {
             let res = [];
 
             const items = core.getInput(name);
@@ -48,9 +48,9 @@ runs:
           // Begin our logic
           const typeValidator = "(chore|feat|fix|revert|docs|style)";
           let identifierValidator = "(\([a-zA-Z0-9- ]+\))?"
-          const enforceJiraIdentifiers = getInputList("enforce_jira_identifiers");
-          if (enforceJiraIdentifiers.length > 0) {
-            identifierValidator = `\((${enforceJiraIdentifiers.join("|")})-[0-9]+`;
+          const enforceIdentifierPrefixes = getInputList("enforce_identifier_prefixes");
+          if (enforceIdentifierPrefixes.length > 0) {
+            identifierValidator = `\((${enforceIdentifierPrefixes.join("|")})-[0-9]+`;
           }
 
           // const validator = /^(chore|feat|fix|revert|docs|style)(\([a-zA-Z0-9- ]+\))?(!)?: (.)+$/

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -49,6 +49,9 @@ runs:
           const typeValidator = "(chore|feat|fix|revert|docs|style)";
           let identifierValidator = "(\([a-zA-Z0-9- ]+\))?"
           const enforceIdentifierPrefixes = getInputList("enforce_identifier_prefixes");
+
+          console.log(`The following identifier prefixes were specified: ${JSON.stringify(enforceIdentifierPrefixes)}`);
+
           if (enforceIdentifierPrefixes.length > 0) {
             identifierValidator = `\((${enforceIdentifierPrefixes.join("|")})-[0-9]+`;
           }

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -19,8 +19,8 @@ runs:
           const {parse} = require('csv-parse/sync');
 
           // From https://github.com/docker/metadata-action/blob/b2391d37b4157fa4aa2e118d643f417910ff3242/src/context.ts#L41
-          const getInputList(name): string[] {
-            const res = [];
+          const getInputList = func(name) {
+            let res = [];
 
             const items = core.getInput(name);
             if (items == '') {

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -1,16 +1,66 @@
 name: Conventional Commits Checking
 description: "Validates that a pull request title is compatible with Conventional Commits."
+inputs:
+  enforce_jira_identifiers:
+    description: "List of JIRA project identifiers to enforce. eg: `feat(FOO-123)` or `feat(BAR-123` pass in FOO\nBAR"
+    required: false
 runs:
   using: composite
   steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "14"
+        check-latest: true
+    - run: npm install csv-parse
     - uses: actions/github-script@v5
       with:
         script: |
-          const validator = /^(chore|feat|fix|revert|docs|style)(\([a-zA-Z0-9- ]+\))?(!)?: (.)+$/
-          const title = context.payload.pull_request.title
-          const is_valid = validator.test(title)
+          const {parse} = require('csv-parse/sync');
 
-          if (!is_valid) {
+          // From https://github.com/docker/metadata-action/blob/b2391d37b4157fa4aa2e118d643f417910ff3242/src/context.ts#L41
+          const getInputList(name): string[] {
+            const res = [];
+
+            const items = core.getInput(name);
+            if (items == '') {
+              return res;
+            }
+
+            const records = parse(items, {
+              columns: false,
+              relaxQuotes: true,
+              comment: '#',
+              relaxColumnCount: true,
+              skipEmptyLines: true
+            });
+
+            for (const record of records) {
+              if (record.length == 1) {
+                res.push(record[0]);
+                continue;
+              }
+              res.push(...record);
+            }
+            return res.filter(item => item).map(pat => pat.trim());
+          }
+
+          // Begin our logic
+          const typeValidator = "(chore|feat|fix|revert|docs|style)";
+          let identifierValidator = "(\([a-zA-Z0-9- ]+\))?"
+          const enforceJiraIdentifiers = getInputList("enforce_jira_identifiers");
+          if (enforceJiraIdentifiers.length > 0) {
+            identifierValidator = `\((${enforceJiraIdentifiers.join("|")})-[0-9]+`;
+          }
+
+          // const validator = /^(chore|feat|fix|revert|docs|style)(\([a-zA-Z0-9- ]+\))?(!)?: (.)+$/
+          const validtor = new RegExp(`^${typeValidator}${identifierValidator}(!)?: (.)+$`);
+
+          console.log(`Will use validator ${validator.toString()}`);
+
+          const title = context.payload.pull_request.title
+          const isValid = validator.test(title)
+
+          if (!isValid) {
             const details = JSON.stringify({
               title: title,
               valid_syntax: validator.toString(),

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -23,6 +23,8 @@ runs:
             let res = [];
 
             const items = core.getInput(name);
+            console.log(`The following input ${name} specified: ${items}`);
+
             if (items == '') {
               return res;
             }
@@ -35,6 +37,8 @@ runs:
               skipEmptyLines: true
             });
 
+            console.log(`The following input ${name} records parsed: ${JSON.stringify(records)}`);
+
             for (const record of records) {
               if (record.length == 1) {
                 res.push(record[0]);
@@ -42,7 +46,8 @@ runs:
               }
               res.push(...record);
             }
-            return res.filter(item => item).map(pat => pat.trim());
+            const cleanRecords = res.filter(item => item).map(pat => pat.trim());
+            return cleanRecords;
           }
 
           // Begin our logic

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -12,6 +12,7 @@ runs:
         node-version: "14"
         check-latest: true
     - run: npm install csv-parse
+      shell: bash
     - uses: actions/github-script@v5
       with:
         script: |

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -54,7 +54,7 @@ runs:
           }
 
           // const validator = /^(chore|feat|fix|revert|docs|style)(\([a-zA-Z0-9- ]+\))?(!)?: (.)+$/
-          const validtor = new RegExp(`^${typeValidator}${identifierValidator}(!)?: (.)+$`);
+          const validator = new RegExp(`^${typeValidator}${identifierValidator}(!)?: (.)+$`);
 
           console.log(`Will use validator ${validator.toString()}`);
 

--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -1,8 +1,8 @@
 name: Conventional Commits Checking
 description: "Validates that a pull request title is compatible with Conventional Commits."
 inputs:
-  enforce_jira_identifiers:
-    description: "List of JIRA project identifiers to enforce. eg: `feat(FOO-123)` or `feat(BAR-123` pass in FOO\nBAR"
+  enforce_identifier_prefixes:
+    description: "List of JIRA (or similar) project identifiers to enforce. eg: `feat(FOO-123):...` or `feat(BAR-123):...` then pass in FOO\nBAR"
     required: false
 runs:
   using: composite

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -47,5 +47,3 @@ runs:
           echo "Creating stack ${STACK_NAME}"
           happy create --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag sha-${GITHUB_SHA} ${STACK_NAME}
         fi
-
-# bump

--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -13,3 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/conventional-commits
+      - uses: ./.github/actions/conventional-commits
+        with:
+          enforce_identifier_prefixes: |
+            CCIE

--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           enforce_identifier_prefixes: |
             CCIE
-            CID
+            CDI

--- a/.github/workflows/conventional_commits_title.yml
+++ b/.github/workflows/conventional_commits_title.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           enforce_identifier_prefixes: |
             CCIE
+            CID


### PR DESCRIPTION
so we can do things like `feat(FOOBAR-123): do the thing`