### PR TITLE
fix: ends with for registry validation

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -34,7 +34,7 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
-          if (`${{ inputs.name }}`.endsWith("/")) {
+          if (`${{ inputs.registry }}`.endsWith("/")) {
             core.setFailed("Don't end a registry with a slash otherwise, we can't log into ECR properly")
           }
     - uses: actions/checkout@v2

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -30,12 +30,13 @@ runs:
   using: "composite"
   steps:
     - name: Prevent registry from ending with a slash
+      id: registry-validation
       uses: actions/github-script@v6
-        with:
-          script: |
-            if (`${{ inputs.name }}`.endsWith("/")) {
-              core.setFailed("Don't end a registry with a slash otherwise, we can't log into ECR properly")
-            }
+      with:
+        script: |
+          if (`${{ inputs.name }}`.endsWith("/")) {
+            core.setFailed("Don't end a registry with a slash otherwise, we can't log into ECR properly")
+          }
     - uses: actions/checkout@v2
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -29,6 +29,13 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Prevent registry from ending with a slash
+      uses: actions/github-script@v6
+        with:
+          script: |
+            if (`${{ inputs.name }}`.endsWith("/")) {
+              core.setFailed("Don't end a registry with a slash otherwise, we can't log into ECR properly")
+            }
     - uses: actions/checkout@v2
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
This PR adds a validation step for the registry input to make sure it doesn't end in a slash. If it does, docker login fails with "unauthorized" which is an error I have encountered a few times now and a total red herring.