### PR TITLE
chore: update happy cli version.

### DIFF
--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -4,7 +4,7 @@ inputs:
   happy_version:
     description: "Version of happy CLI to fetch"
     required: true
-    default: "0.16.0"
+    default: "0.19.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Upgrade to the latest version of the Happy CLI that automatically runs migrations after update when necessary.