### PR TITLE
feat: Support installing the happy CLI system-wide

### DIFF
--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -16,6 +16,7 @@ runs:
       shell: bash
       env:
         HAPPY_VERSION: ${{ inputs.happy_version }}
+        INSTALL_SYSTEMWIDE: ${{ inputs.install_globally }}
       # TODO: cache as in:
       #       https://docs.github.com/en/actions/creating-actions/developing-a-third-party-cli-action
       run: |
@@ -24,6 +25,6 @@ runs:
         wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/happy_${HAPPY_VERSION}_linux_amd64.tar.gz -O happy.tar.gz
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"
-        if [ -n "${{ inputs.install_golbally }}" ]; then
+        if [ -n "${INSTALL_SYSTEMWIDE}" ]; then
             cp happy /usr/local/bin/
         fi

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -5,6 +5,10 @@ inputs:
     description: "Version of happy CLI to fetch"
     required: true
     default: "0.16.0"
+  install_globally:
+    description: "Whether to add happy to the system bin directory"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -20,4 +24,6 @@ runs:
         wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/happy_${HAPPY_VERSION}_linux_amd64.tar.gz -O happy.tar.gz
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"
-# bump2
+        if [ -n "${{ inputs.install_golbally }}" ]; then
+            cp happy /usr/local/bin/
+        fi


### PR DESCRIPTION
We need to be able to run happy via `sudo` in our local dev environments to install `/etc/hosts` overrides. However, when `sudo` is invoked in a github action, it doesn't have access to the updated `$GITHUB_PATH` managed by this action and was unable to find the happy CLI. 