### PR TITLE
feat: add delete functionality to deploy-happy-stack

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "The environment to update or create"
     required: false
   flags:
-    description: "Additional flags to set for happy commands. Flags --aws-profile "" and --env=${ENV} are currently always used."
+    description: "Additional flags to set for happy commands. Flags --aws-profile  and --env=${ENV} are currently always used."
     default: ""
     required: false
 

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -54,7 +54,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^${STACK_NAME}$" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q ${STACK_NAME} ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^\s*\|\s*${STACK_NAME}\s*\|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -1,6 +1,10 @@
 name: Create or Update a Happy Stack
 description: "Will create, update, or delete a Happy Stack"
 inputs:
+  operation:
+    description: "Operation we want this to perform. Defaults to create-or-update. Set to delete if you want to delete the stack."
+    default: ""
+    required: false
   stack-name:
     description: "Name of the stack to create, update, or delete"
     required: true
@@ -22,10 +26,6 @@ inputs:
   env:
     description: "The environment to update or create"
     required: false
-  delete-stack:
-    description: "Should we delete current stack. Defaults to false."
-    default: false
-    required: false
 
 runs:
   using: "composite"
@@ -42,7 +42,7 @@ runs:
         CREATE_TAG: ${{ inputs.create-tag }}
         TAG: ${{ inputs.tag }}
         ENV: ${{ inputs.env }}
-        DELETE_STACK: ${{ inputs.delete-stack }}
+        OPERATION: ${{ inputs.operation }}
       shell: bash
       run: |
         set -ue
@@ -50,14 +50,16 @@ runs:
         
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
+        HAPPY_OPERATION=${OPERATION}
+        HAPPY_DEPLOYMENT_FLAGS=""
 
-        if ${DELETE_STACK}; then
-          echo "Deleting stack ${STACK_NAME}"
-          happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
-          echo "Updating stack ${STACK_NAME}"
-          happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
-        else
-          echo "Creating stack ${STACK_NAME}"
-          happy create --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
-        fi
+        if [[ ${HAPPY_OPERATION} != "create" && ${HAPPY_OPERATION} != "update" && ${HAPPY_OPERATION} != "delete" ]]; then
+          HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
+          if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
+            HAPPY_OPERATION="update"
+          else
+            HAPPY_OPERATION="create"
+          fi
+        echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
+        echo "happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
+        happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -51,8 +51,6 @@ runs:
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
 
-        happy list --aws-profile "" --env=${ENV}
-
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -26,10 +26,6 @@ inputs:
   env:
     description: "The environment to update or create"
     required: false
-  flags:
-    description: "Additional flags to set for happy commands. Flags --aws-profile  and --env=${ENV} are currently always used."
-    default: ""
-    required: false
 
 runs:
   using: "composite"
@@ -47,7 +43,6 @@ runs:
         TAG: ${{ inputs.tag }}
         ENV: ${{ inputs.env }}
         OPERATION: ${{ inputs.operation }}
-        FLAGS: ${{ inputs.flags }}
       shell: bash
       run: |
         set -ue
@@ -55,17 +50,16 @@ runs:
         
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
-        HAPPY_OPERATION=${OPERATION}
-        HAPPY_DEPLOYMENT_FLAGS=${FLAGS}
+        HAPPY_DEPLOYMENT_FLAGS=""
 
-        if [[ ${HAPPY_OPERATION} == "" ]]; then
+        if [[ ${OPERATION} == "" ]]; then
           HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
           if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
-            HAPPY_OPERATION="update"
+            OPERATION="update"
           else
-            HAPPY_OPERATION="create"
+            OPERATION="create"
           fi
         fi
-        echo "Starting to ${HAPPY_OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
-        echo "happy ${HAPPY_OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
-        happy ${HAPPY_OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}
+        echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
+        echo "happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
+        happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "\s*${STACK_NAME}\s*" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "|\s*${STACK_NAME}\s*|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -51,6 +51,8 @@ runs:
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
 
+        happy list --aws-profile "" --env=${ENV}
+
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -61,6 +61,6 @@ runs:
             HAPPY_OPERATION="create"
           fi
         fi
-        echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
-        echo "happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
-        happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}
+        echo "Starting to ${HAPPY_OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
+        echo "happy ${HAPPY_OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
+        happy ${HAPPY_OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -3,7 +3,7 @@ description: "Will create, update, or delete a Happy Stack"
 inputs:
   operation:
     description: "Operation we want this to perform. If not provided, happy will automatically create or update the stack with given name. Could be set to delete to delete the stack."
-    default: ""
+    default: "create-or-update"
     required: false
   stack-name:
     description: "Name of the stack to create, update, or delete"
@@ -52,7 +52,7 @@ runs:
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
         HAPPY_DEPLOYMENT_FLAGS=""
 
-        if [[ ${OPERATION} == "" ]]; then
+        if [[ ${OPERATION} == "create-or-update" ]]; then
           HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
           if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
             OPERATION="update"

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -53,13 +53,14 @@ runs:
         HAPPY_DEPLOYMENT_FLAGS=""
 
         if [[ ${OPERATION} == "create-or-update" ]]; then
-          HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
           if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
             OPERATION="update"
           else
             OPERATION="create"
           fi
-        elif [[ ${OPERATION} == "update" || ${OPERATION} == "create" ]]; then
+        fi
+        
+        if [[ ${OPERATION} == "update" || ${OPERATION} == "create" ]]; then
           HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
         fi
 

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^\s*\|\s*${STACK_NAME}\s*\|" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "\s*\|\s*${STACK_NAME}\s*\|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -54,7 +54,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^${STACK_NAME} " ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^${STACK_NAME}$" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "\s*\|\s*${STACK_NAME}\s*\|" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -60,6 +60,7 @@ runs:
           else
             HAPPY_OPERATION="create"
           fi
+        fi
         echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
         echo "happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
         happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "|\s*${STACK_NAME}\s*|" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -26,6 +26,10 @@ inputs:
   env:
     description: "The environment to update or create"
     required: false
+  flags:
+    description: "Additional flags to set for happy commands. Flags --aws-profile "" and --env=${ENV} are currently always used."
+    default: ""
+    required: false
 
 runs:
   using: "composite"
@@ -43,6 +47,7 @@ runs:
         TAG: ${{ inputs.tag }}
         ENV: ${{ inputs.env }}
         OPERATION: ${{ inputs.operation }}
+        FLAGS: ${{ inputs.flags }}
       shell: bash
       run: |
         set -ue
@@ -51,9 +56,9 @@ runs:
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
         HAPPY_OPERATION=${OPERATION}
-        HAPPY_DEPLOYMENT_FLAGS=""
+        HAPPY_DEPLOYMENT_FLAGS=${FLAGS}
 
-        if [[ ${HAPPY_OPERATION} != "create" && ${HAPPY_OPERATION} != "update" && ${HAPPY_OPERATION} != "delete" ]]; then
+        if [[ ${HAPPY_OPERATION} == "" ]]; then
           HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
           if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^|\s*${STACK_NAME}\s*|" ); then
             HAPPY_OPERATION="update"

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -51,10 +51,12 @@ runs:
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
 
+        happy list --aws-profile "" --env=${ENV}
+
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^\|\s*${STACK_NAME}\s*\|" ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "\s*${STACK_NAME}\s*" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -1,8 +1,8 @@
 name: Create or Update a Happy Stack
-description: "Will create or update a Happy Stack"
+description: "Will create, update, or delete a Happy Stack"
 inputs:
   stack-name:
-    description: "Name of the stack to create or update"
+    description: "Name of the stack to create, update, or delete"
     required: true
   create-tag:
     description: "Should we build and tag docker images. Defaults to false and assumes images already exist."
@@ -22,6 +22,10 @@ inputs:
   env:
     description: "The environment to update or create"
     required: false
+  delete-stack:
+    description: "Should we delete current stack. Defaults to false."
+    default: false
+    required: false
 
 runs:
   using: "composite"
@@ -38,6 +42,7 @@ runs:
         CREATE_TAG: ${{ inputs.create-tag }}
         TAG: ${{ inputs.tag }}
         ENV: ${{ inputs.env }}
+        DELETE_STACK: ${{ inputs.delete-stack }}
       shell: bash
       run: |
         set -ue
@@ -46,7 +51,10 @@ runs:
         IMAGE_TAG="${TAG:-sha-$GITHUB_SHA}"
         echo "Targetting Stack ${STACK_NAME}, tagging with '${IMAGE_TAG}'"
 
-        if $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q ${STACK_NAME} ); then
+        if ${DELETE_STACK}; then
+          echo "Deleting stack ${STACK_NAME}"
+          happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q ${STACK_NAME} ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -56,7 +56,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q ${STACK_NAME} ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q " ${STACK_NAME} " ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -54,7 +54,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q ${STACK_NAME} ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^${STACK_NAME} " ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -2,7 +2,7 @@ name: Create or Update a Happy Stack
 description: "Will create, update, or delete a Happy Stack"
 inputs:
   operation:
-    description: "Operation we want this to perform. Defaults to create-or-update. Set to delete if you want to delete the stack."
+    description: "Operation we want this to perform. If not provided, happy will automatically create or update the stack with given name. Could be set to delete to delete the stack."
     default: ""
     required: false
   stack-name:
@@ -59,7 +59,9 @@ runs:
           else
             OPERATION="create"
           fi
+        elif [[ ${OPERATION} == "update" || ${OPERATION} == "create" ]]; then
+          HAPPY_DEPLOYMENT_FLAGS="--create-tag=${CREATE_TAG} --tag ${IMAGE_TAG}"
         fi
+
         echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
-        echo "happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}"
         happy ${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -54,7 +54,7 @@ runs:
         if ${DELETE_STACK}; then
           echo "Deleting stack ${STACK_NAME}"
           happy delete --aws-profile "" --env=${ENV} ${STACK_NAME}
-        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q " ${STACK_NAME} " ); then
+        elif $(happy list --aws-profile "" --env=${ENV} 2>&1 | grep -q "^\|\s*${STACK_NAME}\s*\|" ); then
           echo "Updating stack ${STACK_NAME}"
           happy update --aws-profile "" --env=${ENV} --create-tag=${CREATE_TAG} --tag ${IMAGE_TAG} ${STACK_NAME}
         else


### PR DESCRIPTION
Background:
The imaging team working on napari-hub wants to deprecate their happy build process and move to using CZI's reusable actions instead. However, the reusable actions currently don't have a way to delete a stack, and we would need to add that functionality to move entirely to using CZI's reusable actions. This change adds additional flexibility for teams managing their stack resources.
Additionally, while testing our changes, we ran into an error where the script wouldn't create a new stack if there was another stack with a name that contained the new stack's name. For example, if we wanted to create a stack called test but we had already made a stack called test-npm, the script would only try to update test because grep had found an occurrence of test in test-npm in the output of happy list.

Changes:
We added a delete functionality to deploy-happy-stack in order to allow us to migrate over fully. To delete a stack, users should set the delete-stack input to true, which would run the happy delete command under the if statement: `if ${DELETE_STACK}; then`, deleting the stack.
We also modified the regex to be more accurate in getting the stack name in the if statement. We're now looking for the pattern `"^|\s*${STACK_NAME}\s*|"` instead of just `${STACK_NAME}`so we can avoid the issue we ran into above. The pattern `"^|\s*${STACK_NAME}\s*|"` looks for a pattern at the beginning of each line that has the STACK_NAME sandwiched between whitespaces and two pipes, which should be able to more accurately check for existence of the correct stack name instead of another stack name that happens to contain that stack name. One remaining issue is that the script won't work if we try to create a happy stack was named NAME because `happy list` will always output NAME as part of the table it creates.

Testing Approach:
The additional if statement was initially tested locally by running a bash script on a mac and ensuring the correct block ran based on whether the DELETE_STACK was true or false. 
We then tested deployments in our branch using this fork until the script was able to create, update, and delete stacks. 
