### PR TITLE
fix: create-or-update check failure 

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -57,7 +57,8 @@ runs:
         HAPPY_DEPLOYMENT_FLAGS=""
 
         if [[ ${OPERATION} == "create-or-update" ]]; then
-          if $(happy list --aws-profile "" --env=${ENV} &>out.txt; grep "^|\s*${STACK_NAME}\s*|" out.txt); then
+          happy list --aws-profile "" --env=${ENV} &> out.txt
+          if grep -q "^|\s*${STACK_NAME}\s*|" out.txt; then
             OPERATION="update"
           else
             OPERATION="create"


### PR DESCRIPTION
The current `create-or-update` check fails as the output from `grep` is the matched line; `$()` attempts to run that line as a command. This fix instead uses grep directly within the if clause instead.