### PR TITLE
fix: add PRODSEC jira project to conventional commits regex

### DIFF
--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/github-script@v5
       with:
         script: |
-          const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|ONCALL)-[0-9]+)|([a-z]+))\))?(!)?: (.)+$/
+          const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|PRODSEC|ONCALL)-[0-9]+)|([a-z]+))\))?(!)?: (.)+$/
           const title = context.payload.pull_request.title
           const is_valid = validator.test(title)
 


### PR DESCRIPTION
As of now, our Conventional Commits github actions doesn’t account for PRODSEC Jira tasks. That means the conventional commits check won’t account for branches/PRs generated from our Jira project.