### PR TITLE
feat: reusable action to delete happy stacks

### DIFF
--- a/.github/actions/happy-cleanup/README.md
+++ b/.github/actions/happy-cleanup/README.md
@@ -17,17 +17,19 @@ on:
     - cron: '55 * * * *'
 jobs:
   build:
-    name: Trigger Site Rebuild
-    runs-on: ubuntu-20.04
+    name: Clean happy stacks
+    runs-on: ubuntu-20.04  
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
+          role-duration-seconds: 1200
+          role-session-name: HappyCleanup
       - name: Clean up stale happy stacks
         uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.0.0
         with:

--- a/.github/actions/happy-cleanup/README.md
+++ b/.github/actions/happy-cleanup/README.md
@@ -1,0 +1,35 @@
+# Happy Cleanup
+This action is meant to assist with the cleanup of stale happy stacks. It should be used with a 
+Github Cron job action, which regularly scans for stacks that have not been updated in a period
+of time and deletes them. This should probably only be utilized in non-production environments.
+
+# Usage
+
+You are required to configure AWS Access that is authorized make all the actions happy needs.
+
+## example
+```yaml
+name: Clean up stale happy stacks every hour
+
+on:
+  schedule:
+    # Runs "at minute 55 past every hour" (see https://crontab.guru)
+    - cron: '55 * * * *'
+jobs:
+  build:
+    name: Trigger Site Rebuild
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
+      - name: Clean up stale happy stacks
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.0.0
+        with:
+          tfe_token: ${{secrets.TFE_TOKEN}}
+```

--- a/.github/actions/happy-cleanup/action.yml
+++ b/.github/actions/happy-cleanup/action.yml
@@ -34,7 +34,7 @@ runs:
         set -ue
         set -o pipefail
 
-        date=`date +%Y-%m-%d'T'%H:%M'Z' -d "$time ago"`
+        date=`date +%Y-%m-%d'T'%H:%M'Z' -d "$TIME ago"`
         for i in $(happy list --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.properties.lastModified < $date)'); do
           happy delete $i --env $ENV
         done

--- a/.github/actions/happy-cleanup/action.yml
+++ b/.github/actions/happy-cleanup/action.yml
@@ -28,12 +28,13 @@ runs:
       env:
         ENV: ${{ inputs.env }}        
         TFE_TOKEN: ${{ inputs.tfe_token }}
+        TIME: ${{inputs.time}}
       shell: bash
       run: |
         set -ue
         set -o pipefail
 
-        date=`date +%Y-%m-%d'T'%H:%M'Z' -d "2 weeks ago"`
+        date=`date +%Y-%m-%d'T'%H:%M'Z' -d "$time ago"`
         for i in $(happy list --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.properties.lastModified < $date)'); do
           happy delete $i --env $ENV
         done

--- a/.github/actions/happy-cleanup/action.yml
+++ b/.github/actions/happy-cleanup/action.yml
@@ -1,0 +1,41 @@
+name: Happy Cleanup
+description: Will list happy stacks in an environment and delete those that have not been updated in a while.
+inputs:
+  env:
+    description: The environment to look for stacks
+    required: true
+    default: rdev
+  time:
+    description: The longest period before a stack should be considered stale. Should be something like '2 weeks' or '1 day'
+    required: true
+    default: 2 weeks
+  tfe_token:
+    description: A Terraform Enterprise API token to be used with your happy organization
+    required: true
+  happy_version:
+    description: The version of happy to use
+    required: true
+    default: latest
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+    - name: Install happy
+      uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.0
+      with:
+        happy_version: ${{ inputs.happy_version }}
+    - name: Delete stale stacks
+      env:
+        ENV: ${{ inputs.env }}        
+        TFE_TOKEN: ${{ inputs.tfe_token }}
+      shell: bash
+      run: |
+        set -ue
+        set -o pipefail
+
+        date=`date +%Y-%m-%d'T'%H:%M'Z' -d "2 weeks ago"`
+        for i in $(happy list --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.properties.lastModified < $date)'); do
+          happy delete $i --env $ENV
+        done
+    
+

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+	".github/actions/happy-cleanup": "1.0.0",
 	".github/actions/conventional-commits": "1.3.1",
 	".github/actions/docker-build-push": "1.3.1",
 	".": "1.10.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -44,6 +44,9 @@
 		".github/actions/retag-happy": {
 			"package-name": "retag-happy"
 		},
+		".github/actions/happy-cleanup": {
+			"package-name": "happy-cleanup"
+		},
 		".": {}
 	}
 }


### PR DESCRIPTION
This PR introduces a reusable Github Action that happy repos can leverage to automatically clean up their stale stacks. This is particularly helpful in development and rdev environments where these can accumulate over time and be annoying to clean up manually. To best use this action, take advantage of the [Github Actions cronjob](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) feature to run the action on a regular interval and only clean up stacks which have not been updated in a selected period of time.