### PR TITLE
fix: ensure happy asset exists when selecting latest release

### DIFF
--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -81,6 +81,7 @@ runs:
       with:
         releaseNameRegEx: '^v[0-9]+\.[0-9]+\.[0-9]+$'
     - name: Print releases
+      shell: bash
       run: |
         echo "Releases: ${{ steps.getReleases.outputs }}"
 

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -76,7 +76,7 @@ runs:
         rm -rf /tmp/aws/
 
     - name: Determine happy version to use
-      id: getReleases
+      id: determineLatestHappyCli
       uses: actions/github-script@v6
       with:
         script: |
@@ -104,12 +104,13 @@ runs:
             }
             page += 1;
           }
+          console.log('Latest happy CLI version:', latestHappyCli)
           return latestHappyCli
 
     - name: Print releases
       shell: bash
       run: |
-        echo "Releases: ${{ steps.getReleases.outputs }}"
+        echo "Releases: ${{ steps.determineLatestHappyCli.outputs.result }}"
 
     - name: Install happy
       shell: bash

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -78,6 +78,8 @@ runs:
     - name: Determine happy version to use
       id: getReleases
       uses: cardinalby/git-get-release-action@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       with:
         releaseNameRegEx: '^v[0-9]+\.[0-9]+\.[0-9]+$'
     - name: Print releases

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -57,7 +57,7 @@ runs:
         terraform_version: 1.3.0
     - name: Install AWS CLI v2
       shell: bash
-      run:  |
+      run: |
         set -ue
         set -o pipefail
         AMD_CMD="curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip -v"
@@ -75,7 +75,7 @@ runs:
         sudo /tmp/aws/install --update
         rm -rf /tmp/aws/
 
-    - name: Determine sun platform
+    - name: Determine platform
       shell: bash
       run: |
         set -ue
@@ -99,46 +99,53 @@ runs:
           console.log(`HAPPY_VERSION=${process.env.HAPPY_VERSION}`);
           console.log(`PLATFORM=${process.env.PLATFORM}`);
 
-          let latestHappyCli = undefined;
           if (process.env.HAPPY_VERSION && process.env.HAPPY_VERSION !== 'latest') {
             console.log(`Using happy version ${process.env.HAPPY_VERSION} from input instead of checking for latest version...`);
-            latestHappyCli = process.env.HAPPY_VERSION;
-          } else {
-            let page = 1;
-            while (!latestHappyCli) {
-              const releases = await github.rest.repos.listReleases({
-                owner: 'chanzuckerberg',
-                repo: 'happy',
-                per_page: 100,
-                page,
-              });
-              console.log(`Releases for page=${page}:`, releases.data)
-              const latestRelease = releases.data.find(release => {
-                if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
-                  return false;
-                }
-                const version = release.tag_name.replace(/^v/, '');
-                console.log(`Found candidate release version=${version}. Checking for assets...`);
-                return release.assets.find(asset => asset.name === `happy_${version}_checksums.txt`);
-              });
-              if (latestRelease) {
-                latestHappyCli = latestRelease.tag_name.replace(/^v/, '');
-              }
-              page += 1;
-            }
-            console.log('Latest happy CLI version:', latestHappyCli)
+            core.setOutput('happyVersion', process.env.HAPPY_VERSION);
+            core.setOutput('happyReleaseAsset', `happy_${process.env.HAPPY_VERSION}_${process.env.PLATFORM}.tar.gz`);
+            return;
           }
-          return latestHappyCli
+          
+          let latestHappyCli = undefined;
+          let releaseAsset = undefined;
+          let page = 1;
+          while (!latestHappyCli) {
+            const releases = await github.rest.repos.listReleases({
+              owner: 'chanzuckerberg',
+              repo: 'happy',
+              per_page: 100,
+              page,
+            });
+            console.log(`Releases for page=${page}:`, releases.data)
+            const latestRelease = releases.data.find(release => {
+              if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
+                return false;
+              }
+              const version = release.tag_name.replace(/^v/, '');
+              releaseAsset = `happy_${version}_${process.env.PLATFORM}.tar.gz`;
+              console.log(`Found candidate release version=${version}. Checking for asset ${releaseAsset} ...`);
+              return release.assets.find(asset => asset.name === releaseAsset);
+            });
+            if (latestRelease) {
+              latestHappyCli = latestRelease.tag_name.replace(/^v/, '');
+            }
+            page += 1;
+          }
+          console.log(`Latest happy CLI version=${latestHappyCli}, releaseAsset=${releaseAsset}`)
+          core.setOutput('happyVersion', latestHappyCli);
+          core.setOutput('happyReleaseAsset', releaseAsset);
 
     - name: Print releases
       shell: bash
       run: |
-        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.result }}"
+        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.happyVersion }}"
+        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.happyReleaseAsset }}"
 
     - name: Install happy
       shell: bash
       env:
-        HAPPY_VERSION: ${{ inputs.happy_version }}
+        HAPPY_VERSION: ${{ steps.determineHappyCliVersion.outputs.happyVersion }}
+        HAPPY_RELEASE_ASSET: ${{ steps.determineHappyCliVersion.outputs.happyReleaseAsset }}
         INSTALL_SYSTEMWIDE: ${{ inputs.install_globally }}
         GH_TOKEN: ${{ github.token }}
       # TODO: cache as in:
@@ -147,23 +154,10 @@ runs:
         set -ue
         set -o pipefail
         cd $(mktemp -d)
-        echo Input argument indicated to use Happy version: $HAPPY_VERSION
-        if [ -z $HAPPY_VERSION ] || [ $HAPPY_VERSION == "latest" ]
-        then
-          HAPPY_VERSION=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/chanzuckerberg/happy/releases --paginate -q "[.[] | select(.tag_name | startswith(\"cli-v\")) | .tag_name][0]" | sed -e "s/^[a-z\-]*v//" | head -n 1)
-        fi
-        PLATFORM=$(uname -m)
-        echo Installing Happy version: $HAPPY_VERSION
-        echo Installing Happy platform: $PLATFORM
-        ARM_CMD="wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/happy_${HAPPY_VERSION}_linux_arm64.tar.gz -O happy.tar.gz"
-        AMD_CMD="wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/happy_${HAPPY_VERSION}_linux_amd64.tar.gz -O happy.tar.gz"
-        if [[ $PLATFORM == "arm64" ]]; then
-            $($ARM_CMD)
-        elif [[ $PLATFORM == "aarch64" ]]; then
-            $($ARM_CMD)
-        else
-            $($AMD_CMD)
-        fi
+        echo Installing Happy version: $HAPPY_VERSION ($HAPPY_RELEASE_ASSET)
+
+        wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET}.tar.gz -O happy.tar.gz
+
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"
         if [ -n "${INSTALL_SYSTEMWIDE}" ]; then

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -110,20 +110,14 @@ runs:
           let releaseAsset = undefined;
           let page = 1;
           while (!latestHappyCli) {
-            const releases = await github.rest.repos.listReleases({
-              owner: 'chanzuckerberg',
-              repo: 'happy',
-              per_page: 100,
-              page,
-            });
-            console.log(`Releases for page=${page}:`, releases.data)
+            const releases = await github.rest.repos.listReleases({ owner: 'chanzuckerberg', repo: 'happy', per_page: 100, page });
             const latestRelease = releases.data.find(release => {
               if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
                 return false;
               }
               const version = release.tag_name.replace(/^v/, '');
               releaseAsset = `happy_${version}_${process.env.PLATFORM}.tar.gz`;
-              console.log(`Found candidate release version=${version}. Checking for asset ${releaseAsset} ...`);
+              console.log(`Found candidate release version=${version}. Checking for asset ${releaseAsset}...`);
               return release.assets.find(asset => asset.name === releaseAsset);
             });
             if (latestRelease) {
@@ -134,12 +128,6 @@ runs:
           console.log(`Latest happy CLI version=${latestHappyCli}, releaseAsset=${releaseAsset}`)
           core.setOutput('happyVersion', latestHappyCli);
           core.setOutput('happyReleaseAsset', releaseAsset);
-
-    - name: Print releases
-      shell: bash
-      run: |
-        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.happyVersion }}"
-        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.happyReleaseAsset }}"
 
     - name: Install happy
       shell: bash
@@ -155,9 +143,7 @@ runs:
         set -o pipefail
         cd $(mktemp -d)
         echo Installing Happy from asset: $HAPPY_RELEASE_ASSET
-
         wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET} -O happy.tar.gz
-
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"
         if [ -n "${INSTALL_SYSTEMWIDE}" ]; then

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -20,6 +20,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine platform
+      shell: bash
+      run: |
+        set -ue
+        set -o pipefail
+        PLATFORM=$(uname -m)
+        if [[ $PLATFORM == "arm64" ]]; then
+            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+        elif [[ $PLATFORM == "aarch64" ]]; then
+            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+        else
+            echo "PLATFORM=linux_amd64" >> $GITHUB_ENV
+        fi
+
     - name: Install gh CLI
       shell: bash
       env:
@@ -29,16 +43,7 @@ runs:
       run: |
         set -ue
         set -o pipefail
-        AMD_URL="https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_amd64.tar.gz"
-        ARM_URL="https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_arm64.tar.gz"
-        PLATFORM=$(uname -m)
-        if [[ $PLATFORM == "arm64" ]]; then
-            URL=$ARM_URL
-        elif [[ $PLATFORM == "aarch64" ]]; then
-            URL=$ARM_URL
-        else
-            URL=$AMD_URL
-        fi
+        URL="https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_${PLATFORM}.tar.gz"
         GHCLI_TOOL_PATH="/tmp/ghcli"
         mkdir -p $GHCLI_TOOL_PATH
         cd /tmp/
@@ -60,34 +65,19 @@ runs:
       run: |
         set -ue
         set -o pipefail
-        AMD_CMD="curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip -v"
-        ARM_CMD="curl https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip -o /tmp/awscliv2.zip -v"
-        PLATFORM=$(uname -m)
-        if [[ $PLATFORM == "arm64" ]]; then
-            $($ARM_CMD)
-        elif [[ $PLATFORM == "aarch64" ]]; then
-            $($ARM_CMD)
+        AMD_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+        ARM_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+        if [[ $PLATFORM == "linux_arm64" ]]; then
+            URL=$ARM_URL
         else
-            $($AMD_CMD)
+            URL=$AMD_URL
         fi
+
+        curl $URL -o /tmp/awscliv2.zip -v
         unzip -q /tmp/awscliv2.zip -d /tmp
         rm /tmp/awscliv2.zip
         sudo /tmp/aws/install --update
         rm -rf /tmp/aws/
-
-    - name: Determine platform
-      shell: bash
-      run: |
-        set -ue
-        set -o pipefail
-        PLATFORM=$(uname -m)
-        if [[ $PLATFORM == "arm64" ]]; then
-            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
-        elif [[ $PLATFORM == "aarch64" ]]; then
-            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
-        else
-            echo "PLATFORM=linux_amd64" >> $GITHUB_ENV
-        fi
 
     - name: Determine happy version to use
       id: determineHappyCliVersion

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -74,6 +74,16 @@ runs:
         rm /tmp/awscliv2.zip
         sudo /tmp/aws/install --update
         rm -rf /tmp/aws/
+
+    - name: Determine happy version to use
+      id: getReleases
+      uses: cardinalby/git-get-release-action@v1
+      with:
+        releaseNameRegEx: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    - name: Print releases
+      run: |
+        echo "Releases: ${{ steps.getReleases.outputs }}"
+
     - name: Install happy
       shell: bash
       env:

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -76,10 +76,15 @@ runs:
         rm -rf /tmp/aws/
 
     - name: Determine happy version to use
-      id: determineLatestHappyCli
+      id: determineHappyCliVersion
       uses: actions/github-script@v6
+      env:
+        HAPPY_VERSION: ${{ inputs.happy_version }}
       with:
         script: |
+          if (process.env.HAPPY_VERSION && process.env.HAPPY_VERSION !== 'latest') {
+            return process.env.HAPPY_VERSION;
+          }
           let latestHappyCli = undefined;
           let page = 1;
           while (!latestHappyCli) {
@@ -110,7 +115,7 @@ runs:
     - name: Print releases
       shell: bash
       run: |
-        echo "Releases: ${{ steps.determineLatestHappyCli.outputs.result }}"
+        echo "Releases: ${{ steps.determineHappyCliVersion.outputs.result }}"
 
     - name: Install happy
       shell: bash

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -83,7 +83,7 @@ runs:
           let latestHappyCli = undefined;
           let page = 1;
           while (!latestHappyCli) {
-            const releases = await github.repos.listReleases({
+            const releases = await github.rest.repos.listReleases({
               owner: 'chanzuckerberg',
               repo: 'happy',
               per_page: 100,

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -77,11 +77,35 @@ runs:
 
     - name: Determine happy version to use
       id: getReleases
-      uses: cardinalby/git-get-release-action@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      uses: actions/github-script@v6
       with:
-        releaseNameRegEx: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+        script: |
+          let latestHappyCli = undefined;
+          let page = 1;
+          while (!latestHappyCli) {
+            const releases = await github.repos.listReleases({
+              owner: 'chanzuckerberg',
+              repo: 'happy',
+              per_page: 100,
+              page,
+            });
+            console.log(`Releases for page=${page}:`, releases.data)
+            const latestRelease = releases.data.find(release => {
+              if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
+                return false;
+              }
+              const version = release.tag_name.replace(/^v/, '');
+              return release.assets.find(asset => {
+                return asset.name === `happy_${version}_checksums.txt`;
+              });
+            });
+            if (latestRelease) {
+              latestHappyCli = latestRelease.tag_name.replace(/^v/, '');
+            }
+            page += 1;
+          }
+          return latestHappyCli
+
     - name: Print releases
       shell: bash
       run: |

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -132,7 +132,7 @@ runs:
         set -ue
         set -o pipefail
         cd $(mktemp -d)
-        echo Installing Happy from asset: $HAPPY_RELEASE_ASSET
+        echo Installing Happy from version $HAPPY_VERSION, asset: $HAPPY_RELEASE_ASSET
         wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET} -O happy.tar.gz
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -77,18 +77,17 @@ runs:
 
     - name: Determine sun platform
       shell: bash
-      with:
-        script: |
-          set -ue
-          set -o pipefail
-          PLATFORM=$(uname -m)
-          if [[ $PLATFORM == "arm64" ]]; then
-              echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
-          elif [[ $PLATFORM == "aarch64" ]]; then
-              echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
-          else
-              echo "PLATFORM=linux_amd64" >> $GITHUB_ENV
-          fi
+      run: |
+        set -ue
+        set -o pipefail
+        PLATFORM=$(uname -m)
+        if [[ $PLATFORM == "arm64" ]]; then
+            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+        elif [[ $PLATFORM == "aarch64" ]]; then
+            echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+        else
+            echo "PLATFORM=linux_amd64" >> $GITHUB_ENV
+        fi
 
     - name: Determine happy version to use
       id: determineHappyCliVersion

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -83,6 +83,7 @@ runs:
       with:
         script: |
           if (process.env.HAPPY_VERSION && process.env.HAPPY_VERSION !== 'latest') {
+            console.log(`Using happy version ${process.env.HAPPY_VERSION} from input instead of checking for latest version...`);
             return process.env.HAPPY_VERSION;
           }
           let latestHappyCli = undefined;

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -156,7 +156,7 @@ runs:
         cd $(mktemp -d)
         echo Installing Happy from asset: $HAPPY_RELEASE_ASSET
 
-        wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET}.tar.gz -O happy.tar.gz
+        wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET} -O happy.tar.gz
 
         tar -xf happy.tar.gz
         echo "${PWD}" >> "${GITHUB_PATH}"

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -154,7 +154,7 @@ runs:
         set -ue
         set -o pipefail
         cd $(mktemp -d)
-        echo Installing Happy version: $HAPPY_VERSION ($HAPPY_RELEASE_ASSET)
+        echo Installing Happy from asset: $HAPPY_RELEASE_ASSET
 
         wget --quiet https://github.com/chanzuckerberg/happy/releases/download/v${HAPPY_VERSION}/${HAPPY_RELEASE_ASSET}.tar.gz -O happy.tar.gz
 

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -75,6 +75,21 @@ runs:
         sudo /tmp/aws/install --update
         rm -rf /tmp/aws/
 
+    - name: Determine sun platform
+      shell: bash
+      with:
+        script: |
+          set -ue
+          set -o pipefail
+          PLATFORM=$(uname -m)
+          if [[ $PLATFORM == "arm64" ]]; then
+              echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+          elif [[ $PLATFORM == "aarch64" ]]; then
+              echo "PLATFORM=linux_arm64" >> $GITHUB_ENV
+          else
+              echo "PLATFORM=linux_amd64" >> $GITHUB_ENV
+          fi
+
     - name: Determine happy version to use
       id: determineHappyCliVersion
       uses: actions/github-script@v6
@@ -82,34 +97,38 @@ runs:
         HAPPY_VERSION: ${{ inputs.happy_version }}
       with:
         script: |
+          console.log(`HAPPY_VERSION=${process.env.HAPPY_VERSION}`);
+          console.log(`PLATFORM=${process.env.PLATFORM}`);
+
+          let latestHappyCli = undefined;
           if (process.env.HAPPY_VERSION && process.env.HAPPY_VERSION !== 'latest') {
             console.log(`Using happy version ${process.env.HAPPY_VERSION} from input instead of checking for latest version...`);
-            return process.env.HAPPY_VERSION;
-          }
-          let latestHappyCli = undefined;
-          let page = 1;
-          while (!latestHappyCli) {
-            const releases = await github.rest.repos.listReleases({
-              owner: 'chanzuckerberg',
-              repo: 'happy',
-              per_page: 100,
-              page,
-            });
-            console.log(`Releases for page=${page}:`, releases.data)
-            const latestRelease = releases.data.find(release => {
-              if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
-                return false;
+            latestHappyCli = process.env.HAPPY_VERSION;
+          } else {
+            let page = 1;
+            while (!latestHappyCli) {
+              const releases = await github.rest.repos.listReleases({
+                owner: 'chanzuckerberg',
+                repo: 'happy',
+                per_page: 100,
+                page,
+              });
+              console.log(`Releases for page=${page}:`, releases.data)
+              const latestRelease = releases.data.find(release => {
+                if (!release.tag_name.match(/^v[0-9]+\.[0-9]+\.[0-9]+$/)) {
+                  return false;
+                }
+                const version = release.tag_name.replace(/^v/, '');
+                console.log(`Found candidate release version=${version}. Checking for assets...`);
+                return release.assets.find(asset => asset.name === `happy_${version}_checksums.txt`);
+              });
+              if (latestRelease) {
+                latestHappyCli = latestRelease.tag_name.replace(/^v/, '');
               }
-              const version = release.tag_name.replace(/^v/, '');
-              console.log(`Found candidate release version=${version}. Checking for assets...`);
-              return release.assets.find(asset => asset.name === `happy_${version}_checksums.txt`);
-            });
-            if (latestRelease) {
-              latestHappyCli = latestRelease.tag_name.replace(/^v/, '');
+              page += 1;
             }
-            page += 1;
+            console.log('Latest happy CLI version:', latestHappyCli)
           }
-          console.log('Latest happy CLI version:', latestHappyCli)
           return latestHappyCli
 
     - name: Print releases

--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -100,9 +100,8 @@ runs:
                 return false;
               }
               const version = release.tag_name.replace(/^v/, '');
-              return release.assets.find(asset => {
-                return asset.name === `happy_${version}_checksums.txt`;
-              });
+              console.log(`Found candidate release version=${version}. Checking for assets...`);
+              return release.assets.find(asset => asset.name === `happy_${version}_checksums.txt`);
             });
             if (latestRelease) {
               latestHappyCli = latestRelease.tag_name.replace(/^v/, '');

--- a/.github/workflows/install-happy.yaml
+++ b/.github/workflows/install-happy.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-happy
         with:
-          happy_version: "0.81.0"
+          happy_version: "1.81.0"
       - run: happy version
       - run: gh auth status
   test-install-happy-x64:

--- a/.github/workflows/install-happy.yaml
+++ b/.github/workflows/install-happy.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-happy
         with:
-          happy_version: "1.81.0"
+          happy_version: "0.81.0"
       - run: happy version
       - run: gh auth status
   test-install-happy-x64:

--- a/.github/workflows/install-happy.yaml
+++ b/.github/workflows/install-happy.yaml
@@ -19,3 +19,9 @@ jobs:
           happy_version: "0.81.0"
       - run: happy version
       - run: gh auth status
+  test-install-happy-x64:
+    runs-on: [self-hosted, linux, X64]
+    steps:
+      - uses: ./.github/actions/install-happy
+      - run: happy version
+      - run: gh auth status

--- a/.github/workflows/install-happy.yaml
+++ b/.github/workflows/install-happy.yaml
@@ -22,6 +22,7 @@ jobs:
   test-install-happy-x64:
     runs-on: [self-hosted, linux, X64]
     steps:
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/install-happy
       - run: happy version
       - run: gh auth status


### PR DESCRIPTION
When choosing the latest happy release we need to check that the asset we want to install has been added by goreleaser. Without this we have seen intermittent failures. re: https://czi-tech.atlassian.net/browse/CCIE-1653

This code uses the following process to choose the happy version to use:
1. Get a list of releases (ordered newest to oldest)
2. Iterate through the releases and when is encountered that has the tag format `v#.#.#` then check for the asset that we need to install
   - If the asset is found: use that version
   - If the asset is not found: continue to the next-newest version with the correct tag format