### PR TITLE
fix: mismatched syntax for jq command in happy cleanup

### DIFF
--- a/.github/actions/happy-cleanup/action.yml
+++ b/.github/actions/happy-cleanup/action.yml
@@ -35,7 +35,7 @@ runs:
         set -o pipefail
 
         date=`date +%Y-%m-%d'T'%H:%M'Z' -d "$TIME ago"`
-        for i in $(happy list --aws-profile "" --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.LastUpdated < $date) | .Name'); do
+        for i in $(happy list --aws-profile "" --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.last_updated < $date) | .stack'); do
           happy delete $i --env $ENV --aws-profile ""
         done
     


### PR DESCRIPTION
The command 
```
happy list --aws-profile "" --output json --env $ENV | jq -r --arg date "$date" '.[] | select(.LastUpdated < $date) | .Name'
```
Should return a list of names of happy stacks from the json output. Instead it returns Nulls.

Updating to 

```
happy list --aws-profile "" --output json --env $ENV | jq -r --arg date 2023-08-23T22:08:49+00:00 '.[] | select(.last_updated < $date) | .stack'
```
returns the expected outcome 