### PR TITLE
feat: add caching for tf providers

### DIFF
--- a/.github/actions/cache-tf-providers/action.yml
+++ b/.github/actions/cache-tf-providers/action.yml
@@ -1,0 +1,81 @@
+name: TF Test
+description: Init, validate, and plan a Terraform workspace. Outputs from the plan are placed in the PR. Terraform plugins and modules are cached using actions/cache.
+inputs:
+  ssh-private-key:
+    description: An SSH key to run `terraform init`
+    required: true
+  tf-version:
+    description: The version of Terraform to use
+    required: true
+  tfe-hostname:
+    description: The hostname of where Terraform Enterprise is located
+    default: si.prod.tfe.czi.technology
+    required: false
+  tfe-token:
+    description: An API token to connect to Terraform Enterprise
+    required: true
+  github-token:
+    description: A Github token to use to comment on this PR
+    required: false
+    default: ${{ github.token }}
+  terragrunt_version:
+    description: The version of Terragrunt to use
+    required: true
+    default: 0.50.8
+  terragrunt_platform:
+    description: The platform to use for Terragrunt
+    required: true
+    default: arm64
+  terraform_plugin_cache_path:
+    description: The path to the Terraform plugin cache
+    required: true
+    default: $HOME/.terraform.d/plugin-cache
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Github SSH known hosts
+      shell: bash
+      run: |
+        mkdir -p ~/.ssh/
+        ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+    - name: Install SSH key
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ inputs.ssh-private-key }}
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: ${{ inputs.tf-version }}
+        cli_config_credentials_hostname: ${{ inputs.tfe-hostname }}
+        cli_config_credentials_token: ${{ inputs.tfe-token }}
+    - name: Config Terraform plugin cache
+      shell: bash
+      run: |      
+        echo 'plugin_cache_dir="${{inputs.terraform_plugin_cache_path}}"' >> ~/.terraformrc
+        mkdir --parents ${{inputs.terraform_plugin_cache_path}}
+    - name: Setup terragrunt
+      id: terragrunt
+      shell: bash
+      run: |
+        GHCLI_TOOL_PATH="/tmp/terragrunt"
+        curl https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.platform }} -o terragrunt
+        mv ./terragrunt ${GHCLI_TOOL_PATH}
+        echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
+    - name: Terraform init
+      id: init 
+      shell: bash
+      run: |
+        #  terraform init for all accounts
+        terragrunt run-all init --terragrunt-working-dir terraform/accounts  --terragrunt-ignore-dependency-errors --terragrunt-ignore-dependency-order --terragrunt-non-interactive
+        # terraform init for all envs
+        for i in $(ls terraform/envs); do terragrunt run-all init --terragrunt-working-dir "terraform/envs/$i"  --terragrunt-ignore-dependency-errors --terragrunt-ignore-dependency-order --terragrunt-non-interactive; done
+    - name: Cache Terraform
+      uses: actions/cache/save@v3
+      with:
+        path: ${{inputs.terraform_plugin_cache_path}}
+        key: ${{runner.os}}-terraform-main-cache
+    

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -62,6 +62,7 @@ runs:
       shell: bash
       run: |
         GHCLI_TOOL_PATH="/tmp/terragrunt"
+        mkdir -p "${GHCLI_TOOL_PATH}"
         curl -L -v -o "${GHCLI_TOOL_PATH}/terragrunt" https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
         echo "done"

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -62,8 +62,7 @@ runs:
       shell: bash
       run: |
         GHCLI_TOOL_PATH="/tmp/terragrunt"
-        curl -L -v -o terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
-        mv ./terragrunt ${GHCLI_TOOL_PATH}
+        curl -L -v -o "${GHCLI_TOOL_PATH}/terragrunt" https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
         echo "done"
         ls /tmp/terragrunt

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -65,6 +65,9 @@ runs:
         curl -L -v -o terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
         mv ./terragrunt ${GHCLI_TOOL_PATH}
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
+        echo "done"
+        ls /tmp/terragrunt
+        cat "${GITHUB_PATH}"
     - name: Terraform init
       id: init 
       shell: bash

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -64,6 +64,7 @@ runs:
         GHCLI_TOOL_PATH="/tmp/terragrunt"
         mkdir -p "${GHCLI_TOOL_PATH}"
         curl -L -v -o "${GHCLI_TOOL_PATH}/terragrunt" https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
+        chmod +x "${GHCLI_TOOL_PATH}/terragrunt"
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
         echo "done"
         ls /tmp/terragrunt

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -29,7 +29,7 @@ inputs:
   terraform_plugin_cache_path:
     description: The path to the Terraform plugin cache
     required: true
-    default: ~/.terraform.d/plugin-cache
+    default: /tmp/.terraform.d/plugin-cache
 
 runs:
   using: "composite"

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -21,7 +21,7 @@ inputs:
   terragrunt_version:
     description: The version of Terragrunt to use
     required: true
-    default: 0.50.8
+    default: v0.50.8
   terragrunt_platform:
     description: The platform to use for Terragrunt
     required: true

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: |
         GHCLI_TOOL_PATH="/tmp/terragrunt"
-        curl https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }} -o terragrunt
+        curl -L -v -o terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }}
         mv ./terragrunt ${GHCLI_TOOL_PATH}
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
     - name: Terraform init

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -29,7 +29,7 @@ inputs:
   terraform_plugin_cache_path:
     description: The path to the Terraform plugin cache
     required: true
-    default: $HOME/.terraform.d/plugin-cache
+    default: ~/.terraform.d/plugin-cache
 
 runs:
   using: "composite"

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -1,5 +1,5 @@
-name: TF Test
-description: Init, validate, and plan a Terraform workspace. Outputs from the plan are placed in the PR. Terraform plugins and modules are cached using actions/cache.
+name: Cache Terraform Providers
+description: Run through a fogg provider installing all the providers and storing them in a Github Action cache location that can be shared by other jobs
 inputs:
   ssh-private-key:
     description: An SSH key to run `terraform init`

--- a/.github/actions/tf-cache-providers/action.yml
+++ b/.github/actions/tf-cache-providers/action.yml
@@ -62,7 +62,7 @@ runs:
       shell: bash
       run: |
         GHCLI_TOOL_PATH="/tmp/terragrunt"
-        curl https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.platform }} -o terragrunt
+        curl https://github.com/gruntwork-io/terragrunt/releases/download/${{ inputs.terragrunt_version }}/terragrunt_linux_${{ inputs.terragrunt_platform }} -o terragrunt
         mv ./terragrunt ${GHCLI_TOOL_PATH}
         echo "${GHCLI_TOOL_PATH}" >> "${GITHUB_PATH}"
     - name: Terraform init

--- a/.github/actions/tf-plan/action.yml
+++ b/.github/actions/tf-plan/action.yml
@@ -1,5 +1,5 @@
-name: TF Test
-description: Init, validate, and plan a Terraform workspace. Outputs from the plan are placed in the PR. Terraform plugins and modules are cached using actions/cache.
+name: Terraform Plan and Validate
+description: Execute a terraform plan and validation on the PR
 inputs:
   ssh-private-key:
     description: An SSH key to run `terraform init`

--- a/.github/actions/tf-plan/action.yml
+++ b/.github/actions/tf-plan/action.yml
@@ -21,6 +21,10 @@ inputs:
   working-dir:
     description: The current working directory of the TFE workspace
     required: true
+  terraform_plugin_cache_path:
+    description: The path to the Terraform plugin cache
+    required: true
+    default: /tmp/.terraform.d/plugin-cache
 
 runs:
   using: "composite"
@@ -46,17 +50,16 @@ runs:
     - name: Config Terraform plugin cache
       shell: bash
       run: |      
-        echo 'plugin_cache_dir="$HOME/.terraform.d/plugin-cache"' >> ~/.terraformrc
-        mkdir --parents ~/.terraform.d/plugin-cache
+        echo 'plugin_cache_dir="${{inputs.terraform_plugin_cache_path}}"' >> ~/.terraformrc
+        mkdir --parents ${{inputs.terraform_plugin_cache_path}}
     ## TODO: Ideally, there would be a parent workflow that would populate
     ## a cache of providers that are required by the whole repo. It might run
     ## on a schedule
     - name: Cache Terraform
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
-        path: ~/.terraform.d/plugin-cache
-        key: ${{runner.os}}-terraform-plan-${{ hashFiles('**/.terraform.lock.hcl') }}
-        restore-keys: ${{runner.os}}-terraform-plan-
+        path: ${{inputs.terraform_plugin_cache_path}}
+        key: ${{runner.os}}-terraform-main-cache
     - name: Terraform init
       id: init 
       shell: bash

--- a/.github/workflows/test-tf-cache.yml
+++ b/.github/workflows/test-tf-cache.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request:
+      branches:
+        - "heathj/cache*"
+      types:
+      - edited
+      - opened
+      - synchronize
+      - reopened
+  
+jobs:
+  tf-test-cache:
+    runs-on: [ARM64,self-hosted,Linux]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Terraform plan
+      uses: ./.github/actions/tf-plan
+      with:
+        ssh-private-key: ${{secrets.SHARED_INFRA_DEPLOY_KEY}}
+        tf-version: 1.3.0
+        tfe-token: ${{secrets.TFE_TOKEN}}

--- a/.github/workflows/test-tf-cache.yml
+++ b/.github/workflows/test-tf-cache.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Terraform plan
-      uses: ./.github/actions/tf-plan
+      uses: ./.github/actions/tf-cache-providers
       with:
         ssh-private-key: ${{secrets.SHARED_INFRA_DEPLOY_KEY}}
         tf-version: 1.3.0

--- a/.github/workflows/test-tf-cache.yml
+++ b/.github/workflows/test-tf-cache.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ARM64,self-hosted,Linux]
     steps:
     - uses: actions/checkout@v3
-    - name: Terraform plan
+    - name: Terraform build cache
       uses: ./.github/actions/tf-cache-providers
       with:
         ssh-private-key: ${{secrets.SHARED_INFRA_DEPLOY_KEY}}

--- a/.github/workflows/test-tf-cache.yml
+++ b/.github/workflows/test-tf-cache.yml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-      branches:
-        - "heathj/cache-providers"
       types:
       - edited
       - opened

--- a/.github/workflows/test-tf-cache.yml
+++ b/.github/workflows/test-tf-cache.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
       branches:
-        - "heathj/cache*"
+        - "heathj/cache-providers"
       types:
       - edited
       - opened

--- a/terraform/accounts/czi-si/.terraform.lock.hcl
+++ b/terraform/accounts/czi-si/.terraform.lock.hcl
@@ -1,0 +1,256 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version = "3.29.0"
+  hashes = [
+    "h1:MGoLSvK5O5GZ3RH9lMlEOnsEqqfP1Khwa4yx0TYgCjg=",
+    "h1:S/qeRtZMsPMVLCcHTNlRVAPRXOCXwNL4StZNnXZTnbo=",
+    "h1:bYiglYs4sDBPyC6v6/DzQvwlSVPgimmOfI0rsIxj6vI=",
+    "h1:nsFCYjxrJWkynzxHAv6Kr7eAlj+Sr+53UAZ12B36PnM=",
+    "zh:35da820fe6bb79f8014117faca7edb379e98161c7efbfe7514024a36b9f0d0ac",
+    "zh:421fd8a6e1a98d110a0db7441a84dcc9ac05c9eba13a612f499e269c98b7cda6",
+    "zh:42bf717a52baaf8c3746dc24712a9454a95b18cd4a23a5e678d86650bca03f5a",
+    "zh:51f926f0410f951667781604d874a47ab5e312eb11ef1c22ec7756f8e287c32e",
+    "zh:696431b43433a1de18cd7d9e5e4633d057790d5f4b1d22f4f74bab22f97930e7",
+    "zh:6d8ecc8b023c700b9f9acfb405bf1c0ef6370d05a08c979b708183b2b33815cc",
+    "zh:7c736730ab40f2742665ee83f6a30dbab234df581b54938f110314d00806608d",
+    "zh:ba783d00aee54e36c59ba03bcb28472289d9e2688fc9e0ba67345957fd682b09",
+    "zh:bb73dce8274bd79456a8aaab9f42aaa816eb9b60271b120ad22d38cedb21adb1",
+    "zh:c75cf41e596c25d282ee188e8efbc0ea91e6cb7d6893c80691810aaa468ca562",
+    "zh:c93415494117051cdb3ccc31689a8545ac70ce9929fa4bef4580ce7a65634480",
+    "zh:d3e3469578c999052b42cb95255f82bd4fbf1f9378963a314d729029322f8c88",
+    "zh:ed5e74b5824ad501e0a0118afb7044ffcfce0ebd9454d9a99f44448a68858e69",
+    "zh:fb86ae545f8eb054d3a9498aed1dce11f74f78265dc7f8e029facaf506433d03",
+  ]
+}
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = ">= 1.14.0"
+  hashes = [
+    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "h1:mX2AOFIMIxJmW5kM8DT51gloIOKCr9iT6W8yodnUyfs=",
+    "h1:tK3u7J4Ojrnx62lRvLok/XGvA7gzMkaVqNOZUDzWKOw=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.13.1"
+  constraints = ">= 3.72.0, >= 4.0.0, >= 4.10.0, >= 4.13.0, >= 4.47.0, >= 4.67.0"
+  hashes = [
+    "h1:T/p3Gp8uAvRk3BmBZI/B7JIUpxF+2DygvBsv2UvJK4w=",
+    "h1:spYQK/G02YRkTfSCnmzLTIIygC+dVQ1axbGgElzhw5w=",
+    "h1:tFQJ6YLOiIlD0kO6QrBwmInHKwQ5Olbyb8kjAYFkrAQ=",
+    "h1:uYJsEJhxGO/dFeK2MsC65wV/NKu7XxnTikh5rbrizBo=",
+    "zh:0d107e410ecfbd5d2fb5ff9793f88e2ce03ae5b3bda4e3b772b5d146cdd859d8",
+    "zh:1080cf6a402939ec4ad393380f2ab2dfdc0e175903e08ed796aa22eb95868847",
+    "zh:300420d642c3ada48cfe633444eafa7bcd410cd6a8503de2384f14ac54dc3ce3",
+    "zh:4e0121014a8d6ef0b1ab4634877545737bb54e951340f1b67ffea8cd22b2d252",
+    "zh:59b401bbf95dc8c6bea58085ff286543380f176271251193eac09cb7fcf619b7",
+    "zh:5dfaf51e979131710ce8e1572e6012564e68c7c842e3d9caaaeb0fe6af15c351",
+    "zh:84bb75dafca056d7c3783be5185187fdd3294f902e9d72f7655f2efb5e066650",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aa4e2b9f699d497041679bc05ca34ac21a5184298eb1813f35455b1883977910",
+    "zh:b51a4f08d84b071128df68a95cfa5114301a50bf8ab8e655dcf7e384e5bc6458",
+    "zh:bce284ac6ebb65053d9b703048e3157bf4175782ea9dbaec9f64dc2b6fcefb0c",
+    "zh:c748f78b79b354794098b06b18a02aefdb49be144dff8876c9204083980f7de0",
+    "zh:ee69d9aef5ca532392cdc26499096f3fa6e55f8622387f78194ebfaadb796aef",
+    "zh:ef561bee58e4976474bc056649095737fa3b2bcb74602032415d770bfc620c1f",
+    "zh:f696d8416c57c31f144d432779ba34764560a95937db3bb3dd2892a791a6d5a7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.10.1"
+  constraints = ">= 2.4.1, >= 2.5.1"
+  hashes = [
+    "h1:OFRsk+lMoRoNoJjJzRngH8hAq++Sb6LwrEKIjd7PeWA=",
+    "h1:ctDhNJU4tEcyoUgPzwKuJmbDIqUl25mCY+s/lVHP6Sg=",
+    "h1:iuVOd7vBg1QwJaW5hLotOfSYcSjddKGGeRKMM0+OSwA=",
+    "h1:rssAXPIBWhumMtToGhh63w1euKOgVOi7+9LK6qZtDUQ=",
+    "zh:0717312baed39fb0a00576297241b69b419880cad8771bf72dec97ebdc96b200",
+    "zh:0e0e287b4e8429a0700143c8159764502eba0b33b1d094bf0d4ef4d93c7802cb",
+    "zh:4f74605377dab4065aaad35a2c5fa6186558c6e2e57b9058bdc8a62cf91857b9",
+    "zh:505f4af4dedb7a4f8f45b4201900b8e16216bdc2a01cc84fe13cdbf937570e7e",
+    "zh:83f37fe692513c0ce307d487248765383e00f9a84ed95f993ce0d3efdf4204d3",
+    "zh:840e5a84e1b5744f0211f611a2c6890da58016a40aafd5971f12285164d4e29b",
+    "zh:8c03d8dee292fa0367b0511cf3e95b706e034f78025f5dff0388116e1798bf47",
+    "zh:937800d1860f6b3adbb20e65f11e5fcd940b21ce8bdb48198630426244691325",
+    "zh:c1853aa5cbbdd1d46f4b169e84c3482103f0e8575a9bb044dbde908e27348c5d",
+    "zh:c9b0f640590da20931c30818b0b0587aa517d5606cb6e8052e4e4bf38f97b54d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe8bd4dd09dc7ca218959eda1ced9115408c2cdc9b4a76964bfa455f3bcadfd3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.23.0"
+  constraints = ">= 2.6.1, >= 2.10.0"
+  hashes = [
+    "h1:PTuAVVjCX41j7T2ffWcWZ1/zSY5N/ysHahvdIvw2IKM=",
+    "h1:arTzD0XG/DswGCAx9JEttkSKe9RyyFW9W7UWcXF13dU=",
+    "h1:cMs2scNCSgQhGamomGT5Ag4i8ms/mql1AR7NJc2hmbA=",
+    "h1:xyFc77aYkPoU4Xt1i5t0B1IaS8TbTtp9aCSuQKDayII=",
+    "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
+    "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
+    "zh:1347cf958ed3f3f80b3c7b3e23ddda3d6c6573a81847a8ee92b7df231c238bf6",
+    "zh:2cb18e9f5156bc1b1ee6bc580a709f7c2737d142722948f4a6c3c8efe757fa8d",
+    "zh:5506aa6f28dcca2a265ccf8e34478b5ec2cb43b867fe6d93b0158f01590fdadd",
+    "zh:6217a20686b631b1dcb448ee4bc795747ebc61b56fbe97a1ad51f375ebb0d996",
+    "zh:8accf916c00579c22806cb771e8909b349ffb7eb29d9c5468d0a3f3166c7a84a",
+    "zh:9379b0b54a0fa030b19c7b9356708ec8489e194c3b5e978df2d31368563308e5",
+    "zh:aa99c580890691036c2931841e88e7ee80d59ae52289c8c2c28ea0ac23e31520",
+    "zh:c57376d169875990ac68664d227fb69cd0037b92d0eba6921d757c3fd1879080",
+    "zh:e6068e3f94f6943b5586557b73f109debe19d1a75ca9273a681d22d1ce066579",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
+    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.9.1"
+  constraints = ">= 0.7.0, >= 0.8.0"
+  hashes = [
+    "h1:NUv/YtEytDQncBQ2mTxnUZEy/rmDlPYmE9h2iokR0vk=",
+    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
+    "h1:VxyoYYOCaJGDmLz4TruZQTSfQhvwEcMxvcKclWdnpbs=",
+    "h1:ZrIFtdifvwIr1JocYT311cvOgIUdislZuZ2MzZmxQQ0=",
+    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
+    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
+    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
+    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
+    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
+    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
+    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
+    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
+    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
+    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.4"
+  hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "h1:bNsvpX5EGuVxgGRXBQVLXlmq40PdoLp8Rfuh1ZmV7yY=",
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/opsgenie/opsgenie" {
+  version     = "0.6.14"
+  constraints = "0.6.14"
+  hashes = [
+    "h1:FhSeND2vv5ythmZyeBteIQEGtQtXFgu/ByiXvVDfdsE=",
+    "h1:N7/ajmejaQyoO7YtsNYvivbKU8pWiJRMmeMY8XQrw0Y=",
+    "h1:Z1Ep4zw0r4L8i1KgjQCsomVFCCYskAQdGOV94a46Ptk=",
+    "h1:r2DsP4cmBfZLvIdvGZfKGrjCngvri0i45xb8iijUvu0=",
+    "zh:1591d84a65af3a2626a3dd8ef62e8694171177018f8787f9d6972ebbca7724df",
+    "zh:329eadda950cce4724747113522c21490d1ca4ac218733b90a1eb1fcaf364ffe",
+    "zh:621c24408b6624b612a12b2a60975e3630357d0c9f2ea7045e45d5fd725fc5f1",
+    "zh:79123177f9cdd94660c7d9feaff439d9f1bcd91959eab5017f7757778d085602",
+    "zh:951d6d270f71ca196dda43ee78b9890d5fca63303dcf26bb1f9c46daeaa1d31e",
+    "zh:a7ee5eae3253cb2bf4f8fe926ab40dc447434b4af527a0c87c179134339d0ac2",
+    "zh:aac4b924baa3ba8da5e056536bf74f10182a0be3a81585e2650db1cbd39e7794",
+    "zh:b132f9df2cf123daac3298e1553014fa32b7761e147a560f17a5f76b9c808424",
+    "zh:ce2bfac2968d859edc3e6e560d550eb16bd167fbf3d21f9971c4b078b3b4dba5",
+    "zh:ddcd99302f6d6c93142e941d0c8534e2c195dba7990209309f17123ec40aa01d",
+    "zh:e55a1122386c0714afb2b0b7481c8259e64ff554bed8de5608dcccae03c96ec6",
+    "zh:ebc8c6e0a6ab8969df3d3e42e12e25bab52dd3881e6cc1f8d4adc74fd74e3eae",
+    "zh:fa75486fd5ca6972ae2210dba751665956debf3e5a3192f5b095a410366db3aa",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "3.1.1"
+  constraints = "3.1.1"
+  hashes = [
+    "h1:B5aaNX/I5gp8Ho+BQPpyhuIMds+6Iip2wxxNUWcX60g=",
+    "h1:SrCoKTGIbLsVsbzQrUB74vwlPyLIdCwSCfOWjhFCaLo=",
+    "h1:ckFJW84aFOnGrVVn812nH/IR3FiPSGFuDEk3wpS31ag=",
+    "h1:rkqjiab6uKn6bKh92drZbF+sf2xcUhVSieR5KVkUs6w=",
+    "zh:0eb43c9df8a5df442e3e3f33090856b7288bb1f3120f6d2f8b318ca55a10f46d",
+    "zh:14184cd1ccb0c6eb1ecb6bcfd817ae6f708bb5d87258f9bf1e9a313b22df150a",
+    "zh:21c045d79860c6ff36a13613ad3b967f7976fc00f3b7557e41c7fdf213f2f1dc",
+    "zh:3411688bb5f4b122548ca6ac957bacf56c6fbadb94c403d7dd310395d9c46cf8",
+    "zh:3422b55ffd363a86ece810f7e5e93469213b42373871dac9cf8b431cde4ec2bd",
+    "zh:42661369270ba2654adc0bbd25e5baeddb114947f8159fd4530b74be5571b461",
+    "zh:8516fe6248792117bb9b35f44fd3be148836b77853b28422ddad88769257775b",
+    "zh:868f9dd8bd012d219dcc98f80b5c8b2d5aef6011c640bfb2a5e505144b3b7225",
+    "zh:9a073b017d07070fd94926f62228736a46b7f9d074168415366a5838da108e58",
+    "zh:a2adcc94dcfe0f507dc91a173baefc891f40073c6911755b25c0d5c2d6858cdf",
+    "zh:ce00436b7a66b66a7485416931280417652090c6efc57b915b7430b5692565df",
+    "zh:f4ae8293d89f85d182ad1a5cbb301069ea7f98ca82e0d780d7b364589b35b0b5",
+  ]
+}

--- a/terraform/accounts/czi-si/.terraform/terraform.tfstate
+++ b/terraform/accounts/czi-si/.terraform/terraform.tfstate
@@ -1,0 +1,28 @@
+{
+    "version": 3,
+    "serial": 1,
+    "lineage": "b083d630-d795-3ad9-9906-fc245586c228",
+    "backend": {
+        "type": "remote",
+        "config": {
+            "hostname": "si.prod.tfe.czi.technology",
+            "organization": "shared-infra",
+            "token": null,
+            "workspaces": {
+                "name": "jheath-test-acction",
+                "prefix": null
+            }
+        },
+        "hash": 1643999911
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/terraform/accounts/czi-si/main.tf
+++ b/terraform/accounts/czi-si/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "remote" {
+    hostname     = "si.prod.tfe.czi.technology"
+    organization = "shared-infra"
+
+    workspaces {
+      name = "jheath-test-acction"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}
+
+resource "random_id" "server" {
+  byte_length = 8
+}

--- a/terraform/accounts/czi-si/terragrunt.hcl
+++ b/terraform/accounts/czi-si/terragrunt.hcl
@@ -1,0 +1,5 @@
+dependencies {
+  paths = [
+ 
+  ]
+}

--- a/terraform/envs/rdev/comp2/terragrunt.hcl
+++ b/terraform/envs/rdev/comp2/terragrunt.hcl
@@ -1,0 +1,5 @@
+dependencies {
+  paths = [
+ 
+  ]
+}

--- a/terraform/envs/rdev/vpc/terragrunt.hcl
+++ b/terraform/envs/rdev/vpc/terragrunt.hcl
@@ -1,0 +1,5 @@
+dependencies {
+  paths = [
+ 
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a workflow that uses terragrunt to initialize all envs and accounts in a github repo. It stores all the downloaded providers in the Github Cache. This should be leveraged in a cron job that runs on the main branch. After the cache is created with the cron job, all child jobs in branches can restore this cache and never need to download providers again. Here is example output from the terraform init in the example folders:


<img width="649" alt="Screenshot 2023-08-28 at 1 25 28 PM" src="https://github.com/chanzuckerberg/github-actions/assets/76011913/3099bbe0-d38a-4629-95ef-d19dea2de046">

