### PR TITLE
fix: CCIE-1770: Add inputs.version_lock_file

### DIFF
--- a/.github/actions/install-happy/action.yaml
+++ b/.github/actions/install-happy/action.yaml
@@ -17,6 +17,10 @@ inputs:
     description: Whether to add happy to the system bin directory
     required: false
     default: ""
+  version_lock_file:
+    description: Path to version.json file
+    required: false
+    default: ".happy/version.lock"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Add missing input parameter `version_lock_file`