### PR TITLE
feat: pass along args to allow a happy deploy from a diff repo

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Github repo to deploy"
     required: false
     default: ""
+  github-token:
+    description: "Github token to use for checkout"
+    required: false
+    default: ""
   github-repo-branch:
     description: "Branch of Github repo to deploy"
     required: false
@@ -66,6 +70,7 @@ runs:
       with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
+          token: ${{ inputs.github-token }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
       with:

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: "Optional stack to pull images from rather than building them (i.e. should be used with image_source_env)"
     required: false
     default: ""
+  repository:
+    description: "Github repo to deploy"
+    required: false
+    default: ""
   github-repo-branch:
     description: "Branch of Github repo to deploy"
     required: false
@@ -60,6 +64,7 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
+          repository: ${{ inputs.repository }}
           ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -54,11 +54,9 @@ inputs:
   repository:
     description: "Github repo to deploy"
     required: false
-    default: ""
   github-token:
     description: "Github token to use for checkout"
     required: false
-    default: ""
   github-repo-branch:
     description: "Branch of Github repo to deploy"
     required: false

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -65,6 +65,7 @@ runs:
     - uses: actions/checkout@v3
       with:
           repository: ${{ inputs.repository }}
+          ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
       with:

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -65,7 +65,6 @@ runs:
     - uses: actions/checkout@v3
       with:
           repository: ${{ inputs.repository }}
-          ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
       with:

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -66,9 +66,9 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
-          repository: ${{ inputs.repository }}
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
-          token: ${{ inputs.github-token }}
+          token: ${{ inputs.github-token || github.token }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main
       with:


### PR DESCRIPTION
### Summary
Add `repository` and `github-token` inputs to the happy deploy. Pass these inputs along to the checkout action, so that we can checkout a different repo from the current.

This helps us trigger a deploy to a happy stack, from a different repo