### PR TITLE
feat: include image-source-role-arn input for deploy happy

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: "Optional stack to pull images from rather than building them (i.e. should be used with image_source_env)"
     required: false
     default: ""
+  image-source-role-arn:
+    description: "Optional role-arn to pull images from rather than building them (i.e. should be used with image_source_env and image_source_stack)"
+    required: false
+    default: ""
   repository:
     description: "Github repo to deploy"
     required: false
@@ -87,6 +91,7 @@ runs:
         SKIP_MIGRATIONS: ${{ inputs.skip-migrations }}
         IMAGE_SOURCE_ENV: ${{ inputs.image-source-env }}
         IMAGE_SOURCE_STACK: ${{ inputs.image-source-stack }}
+        IMAGE_SOURCE_ROLE_ARN: ${{ inputs.image-source-role-arn }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
@@ -119,6 +124,10 @@ runs:
 
         if [[ ${IMAGE_SOURCE_STACK} != "" ]]; then
           HAPPY_DEPLOYMENT_FLAGS="$HAPPY_DEPLOYMENT_FLAGS --image-src-stack ${IMAGE_SOURCE_STACK}"
+        fi
+
+        if [[ ${IMAGE_SOURCE_ROLE_ARN} != "" ]]; then
+          HAPPY_DEPLOYMENT_FLAGS="$HAPPY_DEPLOYMENT_FLAGS --image-src-role-arn ${IMAGE_SOURCE_ROLE_ARN}"
         fi
         echo "Starting to ${OPERATION} stack ${STACK_NAME} with additional flags: ${HAPPY_DEPLOYMENT_FLAGS}"
         echo "Running: '${OPERATION} --aws-profile "" --env=${ENV} ${HAPPY_DEPLOYMENT_FLAGS} ${STACK_NAME}'"


### PR DESCRIPTION
I believe I'll need this full syntax for my actions to work as per @alexlokshin-czi 's comment [here](https://czi-edu.slack.com/archives/C04NVSCDFR7/p1697744689224679?thread_ts=1697230548.141359&cid=C04NVSCDFR7)

```
happy update STAGING_STACK_NAME --env staging --image-src-env rdev --image-src-stack rdev_STACK_NAME --image-src-role-arn "arn:aws:iam::ACCOUNT:role/<rdev-role>"
```