### PR TITLE
fix!: don't checkout ref every time

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -75,10 +75,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.ref_name }}
+          ref: ${{ inputs.github-repo-branch || github.event.pull_request && github.head_ref || github.sha }}
           token: ${{ inputs.github-token || github.token }}
     - name: Install happy
       uses: chanzuckerberg/github-actions/.github/actions/install-happy@main


### PR DESCRIPTION
If there is a commit above yours and you are re-running an action, this checkout will always checkout the `main` ref which will actually be a different SHA than the one that triggered the action in the first place. If you are re-running an action, we should always use the same SHA that triggered the action. BTW, this is the default behavior of [actions/checkout](https://github.com/actions/checkout), we're just writing it out specifically so that you can overwrite it with a input parameter.