### PR TITLE
feat: allow deps for conventional commits

### DIFF
--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/github-script@v5
       with:
         script: |
-          const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|PRODSEC|SECENG|ONCALL)-[0-9]+)|([a-z-]+))\))?(!)?: (.)+$/
+          const validator = /^(chore|feat|fix|deps|revert|docs|style)(\((((CCIE|CDI|PRODSEC|SECENG|ONCALL)-[0-9]+)|([a-z-]+))\))?(!)?: (.)+$/
           const title = context.payload.pull_request.title
           const is_valid = validator.test(title)
 


### PR DESCRIPTION
`deps` is one of the [`release-please` prefixes](
https://github.com/googleapis/release-please#step-1-ensure-releasable-units-are-merged) that triggers a release, and is useful for forcing a release when dependencies are updated (vs. chore).  
