### PR TITLE
fix: Revert "fix: use default token to prevent build cycle"

### DIFF
--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -86,7 +86,7 @@ jobs:
           dockerfile: ${{ github.event.repository.name }}/${{ matrix.image.dockerfile }}
           context: ${{ github.event.repository.name }}/${{ matrix.image.context }}
           name: core-platform/${{ github.event.repository.name }}/${{ matrix.image.name }}
-          registry: 471112759938.dkr.ecr.us-west-2.amazonaws.com
+          registry: 471112759938.dkr.ecr.us-west-2.amazonaws.com 
           custom_tag: ${{ env.IMAGE_TAG }}
           platforms: linux/arm64
           build_args: IMAGE_TAG=${{ env.IMAGE_TAG }}
@@ -100,13 +100,20 @@ jobs:
     if: needs.prep.outputs.image-tag != '' && needs.prep.outputs.image-tag != 'sha-' && needs.prep.outputs.images != '[]'
     permissions:
         id-token: write
-        contents: write
+        contents: read
     steps:
       - run: |
           echo IMAGE_TAG=$IMAGE_TAG
+      - name: Generate token
+        id: generate_token
+        uses: chanzuckerberg/github-app-token@v1.1.4
+        with:
+          app_id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
+          private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Update Manifest
         shell: bash
         run: |


### PR DESCRIPTION
Reverts chanzuckerberg/github-actions#251

We don't want to use the default token because then no jobs run and merging is blocked. The better option is to use the custom token and have the argus docker build job filter based on files changed