### PR TITLE
feat: always log in to core platform prod ECR

### DIFF
--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -88,7 +88,11 @@ runs:
     - name: ecr login
       shell: bash
       run: |
+        # Log in to the platform global ECR and pre-pull any containers you might need
+        # We do this because when we go to build the containers, it won't do the pull through
+        # if the tag or image doesn't exist.
         aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 533267185808.dkr.ecr.us-west-2.amazonaws.com
+        for j in $(for i in $(find . -name "Dockerfile*"); do cat $i | grep "FROM 533267185808" | cut -d " " -f 2;done); do docker pull $j; done
     - name: Create or update happy stack
       env:
         TFE_TOKEN: ${{ inputs.tfe-token }}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -85,14 +85,10 @@ runs:
       with:
         happy_version: ${{ inputs.happy-version }}
         version_lock_file: ${{ inputs.version-lock-file }}
-    - name: ecr login
+    - name: ecr core platform prod login
       shell: bash
       run: |
-        # Log in to the platform global ECR and pre-pull any containers you might need
-        # We do this because when we go to build the containers, it won't do the pull through
-        # if the tag or image doesn't exist.
         aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 533267185808.dkr.ecr.us-west-2.amazonaws.com
-        #for j in $(for i in $(find . -name "Dockerfile*"); do cat $i | grep "FROM 533267185808" | cut -d " " -f 2;done); do docker pull $j; done
     - name: Create or update happy stack
       env:
         TFE_TOKEN: ${{ inputs.tfe-token }}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -85,6 +85,9 @@ runs:
       with:
         happy_version: ${{ inputs.happy-version }}
         version_lock_file: ${{ inputs.version-lock-file }}
+    - name: ecr login
+      run: |
+        aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 533267185808.dkr.ecr.us-west-2.amazonaws.com
     - name: Create or update happy stack
       env:
         TFE_TOKEN: ${{ inputs.tfe-token }}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -92,7 +92,7 @@ runs:
         # We do this because when we go to build the containers, it won't do the pull through
         # if the tag or image doesn't exist.
         aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 533267185808.dkr.ecr.us-west-2.amazonaws.com
-        for j in $(for i in $(find . -name "Dockerfile*"); do cat $i | grep "FROM 533267185808" | cut -d " " -f 2;done); do docker pull $j; done
+        #for j in $(for i in $(find . -name "Dockerfile*"); do cat $i | grep "FROM 533267185808" | cut -d " " -f 2;done); do docker pull $j; done
     - name: Create or update happy stack
       env:
         TFE_TOKEN: ${{ inputs.tfe-token }}

--- a/.github/actions/deploy-happy-stack/action.yml
+++ b/.github/actions/deploy-happy-stack/action.yml
@@ -86,6 +86,7 @@ runs:
         happy_version: ${{ inputs.happy-version }}
         version_lock_file: ${{ inputs.version-lock-file }}
     - name: ecr login
+      shell: bash
       run: |
         aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 533267185808.dkr.ecr.us-west-2.amazonaws.com
     - name: Create or update happy stack


### PR DESCRIPTION
## Summary

This PR updates the deploy happy stack action to always log in to the global ECR in the core platform prod account. This allows folks to use the global pull through caches for dockerhub in their Dockerfiles when using happy.