### PR TITLE
feat: support build_args in argus docker builder workflow

### DIFF
--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -104,7 +104,7 @@ jobs:
 
             const images = JSON.parse(`${{ inputs.images }}`);
             images.forEach(image => {
-              image.build_args = ["IMAGE_TAG=${{ steps.build-tags.outputs.IMAGE_TAG }}", image.build_args...].join("\n");
+              image.build_args = ["IMAGE_TAG=${{ steps.build-tags.outputs.IMAGE_TAG }}", ...image.build_args].join("\n");
             });
             core.info(`Images to build: ${JSON.stringify(images, null, 2)}`);
             core.setOutput('images', images);

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -177,7 +177,8 @@ jobs:
           registry: 533267185808.dkr.ecr.us-west-2.amazonaws.com 
           custom_tag: ${{ env.IMAGE_TAG }}
           platforms: ${{ matrix.image.platform == 'linux/amd64' && 'linux/amd64' || 'linux/arm64' }}
-          build_args: ${{ matrix.image.build_args }}
+          build_args: |
+            ${{ matrix.image.build_args }}
   update-manifests:
     name: Update ArgoCD manifests
     needs: [prep, build-docker]

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -104,7 +104,8 @@ jobs:
 
             const images = JSON.parse(`${{ inputs.images }}`);
             images.forEach(image => {
-              image.build_args = ["IMAGE_TAG=${{ steps.build-tags.outputs.IMAGE_TAG }}", ...image.build_args].join("\n");
+              const buildArgs = image.build_args || [];
+              image.build_args = ["IMAGE_TAG=${{ steps.build-tags.outputs.IMAGE_TAG }}", ...buildArgs].join("\n");
             });
             core.info(`Images to build: ${JSON.stringify(images, null, 2)}`);
             core.setOutput('images', images);

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -92,6 +92,10 @@ jobs:
             core.setOutput('filters', filtersStr);
 
             const images = JSON.parse(`${{ inputs.images }}`);
+            images.forEach(image => {
+              image.build_args = ["IMAGE_TAG=${{ env.IMAGE_TAG }}", image.build_args...].join("\n");
+            });
+            core.info(`Images to build: ${JSON.stringify(images, null, 2)}`);
             core.setOutput('images', images);
 
             const envs = `${{ inputs.envs }}`.split(',').map(env => env.trim()).filter(b => b.length > 0);
@@ -172,8 +176,7 @@ jobs:
           registry: 533267185808.dkr.ecr.us-west-2.amazonaws.com 
           custom_tag: ${{ env.IMAGE_TAG }}
           platforms: ${{ matrix.image.platform == 'linux/amd64' && 'linux/amd64' || 'linux/arm64' }}
-          build_args: IMAGE_TAG=${{ env.IMAGE_TAG }}
-
+          build_args: ${{ matrix.image.build_args }}
   update-manifests:
     name: Update ArgoCD manifests
     needs: [prep, build-docker]

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -178,7 +178,8 @@ jobs:
           custom_tag: ${{ env.IMAGE_TAG }}
           platforms: ${{ matrix.image.platform == 'linux/amd64' && 'linux/amd64' || 'linux/arm64' }}
           build_args: |
-            ${{ matrix.image.build_args }}
+            IMAGE_TAG=${{ env.IMAGE_TAG }}
+            TEST_TEST_TEST=foobarbaz123
   update-manifests:
     name: Update ArgoCD manifests
     needs: [prep, build-docker]

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -82,6 +82,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Get build tag
+        id: build-tags
+        run: |
+          echo "IMAGE_TAG=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Validate build tag
+        id: validate_image_tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const imageTag = `${{ steps.build-tags.outputs.IMAGE_TAG }}`;
+            core.setOutput('image_tag_valid', imageTag !== '' && imageTag !== 'sha-');
       - name: Parse inputs
         id: parse_inputs
         uses: actions/github-script@v7
@@ -93,7 +104,7 @@ jobs:
 
             const images = JSON.parse(`${{ inputs.images }}`);
             images.forEach(image => {
-              image.build_args = ["IMAGE_TAG=${{ env.IMAGE_TAG }}", image.build_args...].join("\n");
+              image.build_args = ["IMAGE_TAG=${{ steps.build-tags.outputs.IMAGE_TAG }}", image.build_args...].join("\n");
             });
             core.info(`Images to build: ${JSON.stringify(images, null, 2)}`);
             core.setOutput('images', images);
@@ -109,17 +120,6 @@ jobs:
             ${{ steps.parse_inputs.outputs.filters }}
           base: ${{ inputs.path_filters_base }}
           list-files: json
-      - name: Get build tag
-        id: build-tags
-        run: |
-          echo "IMAGE_TAG=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Validate build tag
-        id: validate_image_tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const imageTag = `${{ steps.build-tags.outputs.IMAGE_TAG }}`;
-            core.setOutput('image_tag_valid', imageTag !== '' && imageTag !== 'sha-');
 
   build-docker:
     name: Build Docker Image

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -177,9 +177,7 @@ jobs:
           registry: 533267185808.dkr.ecr.us-west-2.amazonaws.com 
           custom_tag: ${{ env.IMAGE_TAG }}
           platforms: ${{ matrix.image.platform == 'linux/amd64' && 'linux/amd64' || 'linux/arm64' }}
-          build_args: |
-            IMAGE_TAG=${{ env.IMAGE_TAG }}
-            TEST_TEST_TEST=foobarbaz123
+          build_args: ${{ matrix.image.build_args }}
   update-manifests:
     name: Update ArgoCD manifests
     needs: [prep, build-docker]


### PR DESCRIPTION
Adds support for specifying `build_args` per image that needs to be built. 

Tested with https://github.com/chanzuckerberg/core-platform-example-app/pull/69/files