### PR TITLE
fix: prevent manifest update after another commit

### DIFF
--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -43,7 +43,8 @@ runs:
             return context.payload.pull_request.head.ref;
           } else if (eventName === "push") {
             // use commit sha if triggered by push
-            return context.sha;
+            // return context.sha;
+            return '';
           } else {
             core.setFailed(`EventName ${eventName} not supported`);
             return;
@@ -52,7 +53,7 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        # ref: ${{ steps.checkout_ref.outputs.result }}
+        ref: ${{ steps.checkout_ref.outputs.result }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7
@@ -95,5 +96,5 @@ runs:
       with:
         add: -A
         message: 'chore: Updated [${{ steps.parse_envs.outputs.envs }}] values.yaml image tags to ${{ inputs.image_tag }}'
-        push: origin ${{ steps.refs.outputs.headRef }}
+        # push: origin ${{ steps.refs.outputs.headRef }}
 

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -52,7 +52,7 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        ref: ${{ steps.checkout_ref.outputs.result }}
+        # ref: ${{ steps.checkout_ref.outputs.result }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -95,5 +95,5 @@ runs:
       with:
         add: -A
         message: 'chore: Updated [${{ steps.parse_envs.outputs.envs }}] values.yaml image tags to ${{ inputs.image_tag }}'
-        push: --set-upstream origin ${{ steps.refs.outputs.headRef }}
+        push: origin ${{ steps.refs.outputs.headRef }}
 

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -32,7 +32,7 @@ runs:
         app_id: ${{ inputs.github_app_id }}
         private_key: ${{ inputs.github_private_key }}
     - name: Determine checkout ref
-      id: checkout_ref
+      id: ref
       uses: actions/github-script@v7
       with:
         result-encoding: string
@@ -42,8 +42,8 @@ runs:
             // use PR head branch name if triggered by PR
             return context.payload.pull_request.head.ref;
           } else if (eventName === "push") {
-            // use commit sha if triggered by push
-            // return context.sha;
+            // return empty string if triggered by push, this is to ensure the checkout action uses the 
+            // default behavior which will prevent race condition commits from multiple builders triggered back-to-back
             return '';
           } else {
             core.setFailed(`EventName ${eventName} not supported`);
@@ -53,7 +53,7 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        ref: ${{ steps.checkout_ref.outputs.result }}
+        ref: ${{ steps.ref.outputs.result }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7
@@ -88,13 +88,8 @@ runs:
             cat ${infra_dir_path}/${env}/values.yaml
           done
         done
-    - name: Calculate Branch and Base Names
-      id: refs
-      uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.6.0
     - name: Update Argus manifests
       uses: EndBug/add-and-commit@v9
       with:
         add: -A
         message: 'chore: Updated [${{ steps.parse_envs.outputs.envs }}] values.yaml image tags to ${{ inputs.image_tag }}'
-        # push: origin ${{ steps.refs.outputs.headRef }}
-

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -31,14 +31,27 @@ runs:
       with:
         app_id: ${{ inputs.github_app_id }}
         private_key: ${{ inputs.github_private_key }}
-    - name: Calculate Branch and Base Names
-      id: refs
-      uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@802010dd523c2b5675134ae49ed8ef257e09705a
+    - name: Determine checkout ref
+      id: ref
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        script: |
+          if (eventName === "pull_request") {
+            // use PR head branch name if triggered by PR
+            return context.payload.pull_request.head.ref;
+          } else if (eventName === "push") {
+            // use commit sha if triggered by push
+            return context.sha;
+          } else {
+            core.setFailed(`EventName ${eventName} not supported`);
+            return;
+          }
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        ref: ${{ steps.refs.outputs.headSha }}
+        ref: ${{ steps.ref.outputs.result }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -32,7 +32,7 @@ runs:
         app_id: ${{ inputs.github_app_id }}
         private_key: ${{ inputs.github_private_key }}
     - name: Determine checkout ref
-      id: ref
+      id: checkout_ref
       uses: actions/github-script@v7
       with:
         result-encoding: string
@@ -52,7 +52,7 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        ref: ${{ steps.ref.outputs.result }}
+        ref: ${{ steps.checkout_ref.outputs.result }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7
@@ -87,9 +87,13 @@ runs:
             cat ${infra_dir_path}/${env}/values.yaml
           done
         done
+    - name: Calculate Branch and Base Names
+      id: refs
+      uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.6.0
     - name: Update Argus manifests
       uses: EndBug/add-and-commit@v9
       with:
         add: -A
         message: 'chore: Updated [${{ steps.parse_envs.outputs.envs }}] values.yaml image tags to ${{ inputs.image_tag }}'
+        push: --set-upstream origin ${{ steps.refs.outputs.headRef }}
 

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -37,6 +37,7 @@ runs:
       with:
         result-encoding: string
         script: |
+          const eventName = context.eventName;
           if (eventName === "pull_request") {
             // use PR head branch name if triggered by PR
             return context.payload.pull_request.head.ref;

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -33,12 +33,12 @@ runs:
         private_key: ${{ inputs.github_private_key }}
     - name: Calculate Branch and Base Names
       id: refs
-      uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.6.0
+      uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@802010dd523c2b5675134ae49ed8ef257e09705a
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ steps.generate_token.outputs.token }}
-        ref: ${{ steps.refs.outputs.headRef }}
+        ref: ${{ steps.refs.outputs.headSha }}
     - name: Parse envs
       id: parse_envs
       uses: actions/github-script@v7

--- a/.github/actions/get-github-ref-names/action.yml
+++ b/.github/actions/get-github-ref-names/action.yml
@@ -10,6 +10,9 @@ outputs:
   headRef:
     description: "The name of our branch's ref"
     value: ${{ steps.refs.outputs.headRef }}
+  headSha:
+    description: "The sha of our branch's ref"
+    value: ${{ steps.refs.outputs.headSha }}
   baseRef:
     description: "The name of the upstream's default ref"
     value: ${{ steps.refs.outputs.baseRef }}
@@ -23,29 +26,35 @@ runs:
       with:
         script: |
           let eventName = context.eventName;
-          let base;
-          let head;
+          let baseRef;
+          let headRef;
+          let headSha;
 
           // TODO: what do we do wrt characters not allowed in docker tags?
           if (eventName === "pull_request") {
-            head = context.payload.pull_request.head.ref;
-            base = context.payload.pull_request.base.ref;
+            headRef = context.payload.pull_request.headRef.ref;
+            headSha = context.payload.pull_request.head.sha;
+            baseRef = context.payload.pull_request.baseRef.ref;
           } else if (eventName === "push") {
             // TODO: this won't work with tags
             const pruneHead = "refs/heads/";
-            head = context.payload.ref.substring(pruneHead.length);
-            base = context.payload.repository.default_branch;
+            headRef = context.payload.ref.substring(pruneHead.length);
+            headSha = context.sha;
+            baseRef = context.payload.repository.default_branch;
           } else if (eventName === "delete") {
-            head = context.payload.repository.default_branch;
-            base = context.payload.ref;
+            headRef = context.payload.repository.default_branch;
+            headSha = context.sha;
+            baseRef = context.payload.ref;
           } else if (eventName === "release") {
-            head = context.payload.repository.default_branch;
-            base = context.payload.repository.default_branch;
+            headRef = context.payload.repository.default_branch;
+            headSha = context.sha;
+            baseRef = context.payload.repository.default_branch;
           } else {
             core.setFailed(`EventName ${eventName} not supported`);
             return;
           }
 
-          core.setOutput("headRef", head);
-          core.setOutput("baseRef", base);
-          console.log(`Calculated the following ${JSON.stringify({eventName,base,head}, null, 2)}`);
+          core.setOutput("headRef", headRef);
+          core.setOutput("headSha", headSha);
+          core.setOutput("baseRef", baseRef);
+          console.log(`Calculated the following ${JSON.stringify({eventName,baseRef,headRef,headSha}, null, 2)}`);

--- a/.github/actions/get-github-ref-names/action.yml
+++ b/.github/actions/get-github-ref-names/action.yml
@@ -10,9 +10,6 @@ outputs:
   headRef:
     description: "The name of our branch's ref"
     value: ${{ steps.refs.outputs.headRef }}
-  headSha:
-    description: "The sha of our branch's ref"
-    value: ${{ steps.refs.outputs.headSha }}
   baseRef:
     description: "The name of the upstream's default ref"
     value: ${{ steps.refs.outputs.baseRef }}
@@ -26,35 +23,29 @@ runs:
       with:
         script: |
           let eventName = context.eventName;
-          let baseRef;
-          let headRef;
-          let headSha;
+          let base;
+          let head;
 
           // TODO: what do we do wrt characters not allowed in docker tags?
           if (eventName === "pull_request") {
-            headRef = context.payload.pull_request.headRef.ref;
-            headSha = context.payload.pull_request.head.sha;
-            baseRef = context.payload.pull_request.baseRef.ref;
+            head = context.payload.pull_request.head.ref;
+            base = context.payload.pull_request.base.ref;
           } else if (eventName === "push") {
             // TODO: this won't work with tags
             const pruneHead = "refs/heads/";
-            headRef = context.payload.ref.substring(pruneHead.length);
-            headSha = context.sha;
-            baseRef = context.payload.repository.default_branch;
+            head = context.payload.ref.substring(pruneHead.length);
+            base = context.payload.repository.default_branch;
           } else if (eventName === "delete") {
-            headRef = context.payload.repository.default_branch;
-            headSha = context.sha;
-            baseRef = context.payload.ref;
+            head = context.payload.repository.default_branch;
+            base = context.payload.ref;
           } else if (eventName === "release") {
-            headRef = context.payload.repository.default_branch;
-            headSha = context.sha;
-            baseRef = context.payload.repository.default_branch;
+            head = context.payload.repository.default_branch;
+            base = context.payload.repository.default_branch;
           } else {
             core.setFailed(`EventName ${eventName} not supported`);
             return;
           }
 
-          core.setOutput("headRef", headRef);
-          core.setOutput("headSha", headSha);
-          core.setOutput("baseRef", baseRef);
-          console.log(`Calculated the following ${JSON.stringify({eventName,baseRef,headRef,headSha}, null, 2)}`);
+          core.setOutput("headRef", head);
+          core.setOutput("baseRef", base);
+          console.log(`Calculated the following ${JSON.stringify({eventName,base,head}, null, 2)}`);

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -236,7 +236,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@258ab59196f6952756a0285fcd92100317035a03
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@313e29aaee9797a3a83862c51423f87cc5be2da8
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: read
     steps:
       - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/build-prep@f801d1e293e6275cc1f5c0d6061ff0e3de640589
         id: build_prep

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -237,7 +237,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@313e29aaee9797a3a83862c51423f87cc5be2da8
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@860b1ad395f79f5892f842ee9564737a1b5735b1
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -236,7 +236,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@8a46805ca8e5b91bfa8959587a00b5526a35d14e
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@258ab59196f6952756a0285fcd92100317035a03
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -237,7 +237,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@364b63980f3d0dacd7627307a3557c7759e73801
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@0b9b41fa49ec6d64bacbeab699712434e79c3476
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -236,7 +236,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@f801d1e293e6275cc1f5c0d6061ff0e3de640589
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@1d9bf906b6c590545b903b4e894004eb9e8a6957
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -237,7 +237,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@860b1ad395f79f5892f842ee9564737a1b5735b1
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@364b63980f3d0dacd7627307a3557c7759e73801
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -236,7 +236,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@1d9bf906b6c590545b903b4e894004eb9e8a6957
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@8a46805ca8e5b91bfa8959587a00b5526a35d14e
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}


### PR DESCRIPTION
The recent update to this builder action to support triggering it from a `pull_request` trigger involved a change to the checkout action that caused some issues. In the image below, the commits from the builder are dependent on how long it takes to build, meaning sometimes a prior build that took longer to build would overwrite a more recent build that had already committed back to the values yaml.

---

<img width="832" alt="Screenshot 2024-09-20 at 2 38 55 PM" src="https://github.com/user-attachments/assets/f9af0d9c-3195-43b3-a279-8815804b47ff">

---

This issue arose because the checkout action started receiving a `ref` argument that would be set to the branch name in the case of a `push` event, this caused the job to checkout the latest from the branch and then push over whatever was already there. Not supplying the `ref`, or setting it to an empty string, causes the checkout action to fetch at the point that the workflow was triggered, which in turn causes the commit of the build sha to fail if a newer commit has updated the build sha since the job was initially invoked.