### PR TITLE
chore: roll back mutliple projectKey support

### DIFF
--- a/.github/actions/jira-find-marker/action.yaml
+++ b/.github/actions/jira-find-marker/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: The Github PR body
     required: true
     type: string
-  projectKeys:
+  projectKey:
     description: The Jira project keys to look for (comma delimited)
     required: true
     type: string
@@ -32,21 +32,9 @@ runs:
             return;
           }
 
-          const projectKeys = `${{ inputs.projectKeys }}`.split(',').map(env => env.trim()).filter(b => b.length > 0);
-
-          let markerMatch = null;
-          projectKeys.find(projectKey => {
-            console.log('Searching for Jira marker in PR body for project key:', projectKey);
-            const markerRegex = new RegExp(`<!--JIRA_VALIDATE_START:(${projectKey}-\\d+):do not remove this marker as it will break the jira validation functionality-->[\\s\\S]+<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->\\s+---\\s+`);
-            const matchResult = pullRequestBody.match(markerRegex);
-            if (matchResult && matchResult.length >= 2) {
-              markerMatch = matchResult;
-              return true;
-            }
-            return false;
-          });
-
-          if (!markerMatch) {
+          const markerRegex = new RegExp(`<!--JIRA_VALIDATE_START:(${{ inputs.projectKey }}-\\d+):do not remove this marker as it will break the jira validation functionality-->[\\s\\S]+<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->\\s+---\\s+`);
+          const markerMatch = pullRequestBody.match(markerRegex);
+          if (!markerMatch || markerMatch.length < 2) {
             console.log('No Jira marker found in PR body');
             return;
           }

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -96,7 +96,7 @@ runs:
           })
 
           for (let comment of comments) {
-            if (comment.body === noJiraIssueBody && user.type === 'Bot') {
+            if (comment.body === noJiraIssueBody && comment.user.type === 'Bot') {
               console.log('Found comment:', JSON.stringify(comment, null, 2));
               await github.rest.issues.deleteComment({
                 owner,

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -96,7 +96,7 @@ runs:
           })
 
           for (let comment of comments) {
-            if (comment.body === noJiraIssueBody) {
+            if (comment.body === noJiraIssueBody && user.type === 'Bot') {
               console.log('Found comment:', JSON.stringify(comment, null, 2));
               await github.rest.issues.deleteComment({
                 owner,
@@ -113,7 +113,7 @@ runs:
               issue_number: ${{ github.event.pull_request.number }},
               body: noJiraIssueBody,
             });
-            throw new Error(body);
+            throw new Error(noJiraIssueBody);
           }
           return jiraIssueRef;
 

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -6,7 +6,7 @@ description: |
   the PR body (or update the existing summary if it already exists).
 
 inputs:
-  projectKeys:
+  projectKey:
     description: The Jira project keys to look for (comma delimited)
     required: true
     type: string
@@ -68,34 +68,26 @@ runs:
         script: |
           const prBody = ${{ steps.getPullRequest.outputs.prBody }};
           const prTitle = ${{ steps.getPullRequest.outputs.prTitle }};
-          const projectKeys = `${{ inputs.projectKeys }}`.split(',').map(env => env.trim()).filter(b => b.length > 0);
-          if (projectKeys.length === 0) {
-            throw new Error('No projectKeys provided');
-          }
-
-          const issueRegexes = projectKeys.map(projectKey => new RegExp(`${projectKey}-\\d+`));
 
           let jiraIssueRef = null;
+          const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);
           [
             { label: 'branch', value: '${{ github.head_ref }}' },
             { label: 'title', value: prTitle },
             { label: 'body', value: prBody },
           ].find(({label, value}) => {
-            const found = issueRegexes.find(issueRegex => {
-              const match = value.match(issueRegex);
-              if (match) {
-                jiraIssueRef = match[0];
-                console.log(`Found Jira issue reference in PR ${label}: ${jiraIssueRef}`);
-                return true;
-              }
-              return false;
-            });
-            return found;
+            const match = value.match(issueRegex);
+            if (match) {
+              jiraIssueRef = match[0];
+              console.log(`Found Jira issue reference in PR ${label}: ${jiraIssueRef}`);
+              return true;
+            }
+            return false;
           });
 
           const ownerAndRepo = '${{ github.repository }}';
           const [owner, repo] = ownerAndRepo.split('/');
-          const noJiraIssueBody = `No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of PROJECTKEY-#### (eg: ${projectKeys[0]}-1234) to the branch name, title, or body of your PR.`;
+          const noJiraIssueBody = `No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of ${{ inputs.projectKey }}-#### (eg: ${{ inputs.projectKey }}-1234) to the branch name, title, or body of your PR.`;
 
           const { data: comments } = await github.rest.issues.listComments({
             owner,
@@ -149,10 +141,10 @@ runs:
     - name: Find Jira Marker
       id: findJiraMarker
       if: steps.checkIfJobShouldRun.outputs.result == 'true'
-      uses: chanzuckerberg/github-actions/.github/actions/jira-find-marker@885251a38b81dbb9b6ab0b106dc31ec2f5703764
+      uses: chanzuckerberg/github-actions/.github/actions/jira-find-marker@a9fcc1eebdf68758ed741a0828e1c822a3b3177e
       with:
         pullRequestBody: ${{ steps.getPullRequest.outputs.prBody }}
-        projectKeys: ${{ inputs.projectKeys }}
+        projectKey: ${{ inputs.projectKey }}
 
     - name: Update PR Body
       uses: actions/github-script@v7

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -97,7 +97,7 @@ runs:
 
           for (let comment of comments) {
             if (comment.body === noJiraIssueBody && comment.user.type === 'Bot') {
-              console.log('Found comment:', JSON.stringify(comment, null, 2));
+              console.log('Found comment to delete:', JSON.stringify(comment, null, 2));
               await github.rest.issues.deleteComment({
                 owner,
                 repo,


### PR DESCRIPTION
We can't support multiple project keys because the Jira Release can only contain issues from the same project it is a part of