### PR TITLE
fix: bash script in happy-cleanup github action

### DIFF
--- a/.github/actions/happy-cleanup/action.yml
+++ b/.github/actions/happy-cleanup/action.yml
@@ -58,20 +58,20 @@ runs:
         set -o pipefail
 
         date=`date +%Y-%m-%d'T'%H:%M'Z' -d "$TIME ago"`
-        list="happy list --aws-profile "" --output json --env $ENV"
+        list=("happy" "list" "--aws-profile" "" "--output" "json" "--env" "$ENV")
         force=""
         if [[ ${ALL} ]]; then
-          list="happy list --aws-profile "" --all --output json --env $ENV"
+          list=("happy" "list" "--aws-profile" "" "--output" "json" "--env" "$ENV")
           force="--force"
         fi
         if [[ ! -z ${EXCLUDE} ]]; then
-          for i in $($(echo $list) | jq -r --arg date "$date" --arg exclude "$EXCLUDE" '.[] | select(.last_updated < $date) | select(any(.stack; contains($exclude))|not) | .stack'); do
+          for i in $("${list[@]}" | jq -r --arg date "$date" --arg exclude "$EXCLUDE" '.[] | select(.last_updated < $date) | select(any(.stack; contains($exclude))|not) | .stack'); do
             echo "Deleting stack: $i"
             happy delete --aws-profile "" $i --env $ENV "$force"
           done
           exit
         fi
-        for i in $($(echo $list) | jq -r --arg date "$date" '.[] | select(.last_updated < $date) | .stack'); do
+        for i in $("${list[@]}" | jq -r --arg date "$date" '.[] | select(.last_updated < $date) | .stack'); do
           echo "Deleting stack: $i"
           happy delete --aws-profile "" $i --env $ENV "$force"
         done


### PR DESCRIPTION
### Summary
Fix happy-cleanup job in github actions. In the original script, the empty string in the optional argument `--aws-profile ""` is being stripped in `$(echo $list)`, resulting in the following error (since the happy command isn't using the default aws credentials chain)
> Error: unable to initialize the happy client: unable to retrieve aws account id: could not get identity: operation error STS: GetCallerIdentity, get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, canceled, context deadline exceeded



ChatGPT suggested to use an array and the `@` symbol to expand the contents of an array in order to preserve any empty spaces/escaping. 

### Test Plan
I tried this out in a [test branch](https://github.com/chanzuckerberg/bento/actions/runs/12021899289/job/33557588614) and it works! 