### PR TITLE
fix: do not update manifest on PRs without stack label

### DIFF
--- a/.github/actions/argus-builder/build-prep/action.yml
+++ b/.github/actions/argus-builder/build-prep/action.yml
@@ -21,6 +21,13 @@ inputs:
     description: 'Branch names to run this job on, supports wildcards, comma delimited'
     required: false
     default: ''
+  pr_labels:
+    description: 'Labels attached to an associated PR'
+    required: false
+    default: ''
+  manifest_trigger_label:
+    description: 'Label that will trigger updating the manifest and committing a docker image change to values.yaml'
+    default: 'stack'
 
 outputs:
   image_tag:
@@ -29,6 +36,9 @@ outputs:
   should_build:
     description: Whether the job should run
     value: ${{ steps.final_check.outputs.should_build }}
+  should_deploy:
+    description: Whether or not the build is to be deployed to a stack
+    value: ${{ steps.require_stack_label.outputs.should_deploy }}
 
 runs:
   using: composite
@@ -94,6 +104,7 @@ runs:
           const filters = `${{ inputs.path_filters }}`.split(',').map(f => f.trim()).filter(b => b.length > 0);
           const filtersStr = "run_on:\n" + filters.map(f => `  - '${f}'`).join('\n');
           core.setOutput('filters', filtersStr);
+          console.log(`Filters: ${filtersStr}`);
 
     - name: Check for force push
       id: force_push
@@ -119,6 +130,17 @@ runs:
         base: ${{ steps.force_push.outputs.base }}
         list-files: json
 
+    - name: Require manifest trigger label in pull requests
+      id: require_stack_label
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const labels = `${{ inputs.pr_labels }}`;
+          const triggerLabel = `${{ inputs.manifest_trigger_label }}`;
+          const hasTriggerLabel = labels.split(',').map(l => l.trim()).includes(triggerLabel);
+          console.log(`Detected labels ${labels} on PR. Has ${triggerLabel} label? ${hasTriggerLabel}`);
+          core.setOutput('should_deploy', hasTriggerLabel);
+
     - name: Check if build should run
       id: final_check
       uses: actions/github-script@v7
@@ -126,4 +148,6 @@ runs:
         script: |
           const branchMatched = `${{ steps.branch_filter.outputs.match }}` === 'true';
           const filesMatched = `${{ steps.file_filter.outputs.run_on }}` === 'true';
-          core.setOutput('should_build', filesMatched && branchMatched);
+          const shouldBuild = filesMatched && branchMatched;
+          core.setOutput('should_build', shouldBuild);
+          console.log(`Branch matched? ${branchMatched}. Files matched? ${filesMatched}. Build should run? ${shouldBuild}`);

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -48,20 +48,26 @@ jobs:
     outputs:
       image_tag: ${{ steps.build_prep.outputs.image_tag }}
       should_build: ${{ steps.build_prep.outputs.should_build }}
+      should_deploy: ${{ steps.build_prep.outputs.should_deploy }}
       images: ${{ steps.parse_images.outputs.images }}
     permissions:
       id-token: write
       contents: read
       pull-requests: read
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/build-prep@v3.4.1
+      - uses: 8BitJonny/gh-get-current-pr@3.0.0
+        id: findPr
+        with:
+          filterOutClosed: true
+          filterOutDraft: false
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/build-prep@rzheng/stack-label
         id: build_prep
         with:
           path_filters: ${{ inputs.path_filters }}
           path_filters_base: ${{ inputs.path_filters_base }}
           branches_include: ${{ inputs.branches_include }}
           branches_ignore: ${{ inputs.branches_ignore }}
-      
+          pr_labels: ${{ steps.findPr.outputs.pr_labels }}
       - uses: actions/checkout@v4
       - uses: chanzuckerberg/github-actions/.github/actions/validate-json-schema@v3.4.1
         name: Validate images input
@@ -219,7 +225,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    if: always() && inputs.update_manifests && needs.prep.outputs.should_build == 'true' && needs.prep.outputs.images != '[]'
+    if: always() && inputs.update_manifests && needs.prep.outputs.should_build == 'true'&& needs.prep.outputs.should_deploy == 'true' && needs.prep.outputs.images != '[]'
     steps:
       - name: Check build status
         uses: actions/github-script@v7


### PR DESCRIPTION
Attempts to address https://github.com/chanzuckerberg/argus/issues/655 by running `Update ArgoCD manifests` only if a PR associated with a push has the `stack` label.

Tested via https://github.com/chanzuckerberg/core-platform-example-app/pull/112 which is on 2.X of this action (hence the merge conflicts).

If we like this approach, what should I do? Maybe create 2.16.0 and 3.7.0? Do we care about supporting 2.X apps? It would be simpler to ask those app owners to use 3.X to gain this benefit. Prior to merging I will rebase on latest and test again on an app using 3.X.

Requires application owners to upgrade their argus-docker-build.yaml version target

- [ ] after merging update the tag of build-prep