### PR TITLE
feat!: CCIE-3896 rename CZI_GITHUB_HELPER_* to GH_ACTIONS_HELPER_*

### DIFF
--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -215,8 +215,8 @@ jobs:
           build_args: ${{ matrix.image.build_args }}
           secret_files: ${{ matrix.image.secret_files }}
           image_tag: ${{ needs.prep.outputs.image_tag }}
-          github_app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
-          github_private_key: ${{ secrets.CZI_GITHUB_HELPER_PK }}
+          github_app_id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
+          github_private_key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
 
   update-manifests:
     name: Update ArgoCD manifests
@@ -254,5 +254,5 @@ jobs:
           envs: ${{ inputs.envs }}
           image_tag: ${{ needs.prep.outputs.image_tag }}
           argus_project_dirs: ${{ steps.determine_manifests.outputs.result }}
-          github_app_id: ${{ secrets.CZI_GITHUB_HELPER_APP_ID }}
-          github_private_key: ${{ secrets.CZI_GITHUB_HELPER_PK }}
+          github_app_id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
+          github_private_key: ${{ secrets.GH_ACTIONS_HELPER_PK }}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ Each workflow will be released with a distinct tag following semver and conventi
 NOTE:
 
 GitHub has an undocumented limitation with reusable Actions -- they must all live under `.github/workflows/`
+
+## Installation
+
+For some actions you will need to have a helper Github
+Application configured to act on behalf of Actions.
+Please [register an app](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app)
+and set these organization level
+[Github action secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions).
+
+* GH_ACTIONS_HELPER_APP_ID - app id of the github app you created
+* GH_ACTIONS_HELPER_PK - you need to generate a private key in the app settings and set the value of this secret to the private key


### PR DESCRIPTION
BREAKING CHANGE: requires renaming of org level secrets

* Might consider bundling together with other breaking changes (if any) that may arise from making this repo reusable across orgs
* Cannot rename to `GITHUB_HELPER_*` bc the `GITHUB_` prefix is reserved
* I don't think the GH app is checked into IaC right? anyone reading the README will likely have to reach out to our team to figure out app settings/permissions.
* I generated a new PK for the `CZI Github Helper` app and added `GH_ACTIONS_HELPER_APP_ID` & `GH_ACTIONS_HELPER_PK` as new org secrets. we should delete the old ones after this merges.