### PR TITLE
feat: CCIE-3978 make argus-docker-build runs-on configurable

### DIFF
--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -44,11 +44,21 @@ on:
         required: false
         type: boolean
         default: false
+      arm_runner_labels:
+        description: 'Runner label to use for steps that use an arm-based action runner'
+        required: false
+        type: string
+        default: "['ARM64']"
+      x64_runner_labels:
+        description: 'Runner label to use for steps that use an x64-based action runner'
+        required: false
+        type: string
+        default: "['X64']"
 
 jobs:
   prep:
     name: Prep for Build
-    runs-on: [ARM64]
+    runs-on: ${{ fromJSON(inputs.arm_runner_labels) }}
     if: contains(github.event.head_commit.message, '[no-deploy]') == false
     outputs:
       image_tag: ${{ steps.build_prep.outputs.image_tag }}
@@ -191,8 +201,7 @@ jobs:
   build-docker:
     name: Build Docker Image
     needs: [prep]
-    runs-on:
-      - ${{ matrix.image.platform == 'linux/amd64' && 'X64' || 'ARM64' }}
+    runs-on: ${{ matrix.image.platform == 'linux/amd64' && fromJSON(inputs.x64_runner_labels) || fromJSON(inputs.arm_runner_labels) }}
     if: needs.prep.outputs.should_build == 'true' && needs.prep.outputs.images != '[]'
     permissions:
       id-token: write
@@ -225,7 +234,7 @@ jobs:
   update-manifests:
     name: Update ArgoCD manifests
     needs: [prep, build-docker]
-    runs-on: [ARM64]
+    runs-on: ${{ fromJSON(inputs.arm_runner_labels) }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Considerations:

1. Github workflows apparently do not allow using a list as an input. I want to support the runs-on labels with more than 1 selector so a workaround I found is to pass a JSON string that gets decoded using `fromJSON()`.
2. Github-hosted arm-based runners are not enabled for private repos
![image](https://github.com/user-attachments/assets/7261013e-a199-442e-a1b2-f46697e79f38)
3. There is no way to use x64 for both build-prep and x64 matrix img build steps (not sure if there's a use case for this)

tested in https://github.com/chanzuckerberg/core-platform-example-app/pull/112

are there any other workflows that we want to make `runs-on` configurable? `install-happy` and `test-tfe-cache` are using custom runners but not sure if those should be configurable