### PR TITLE
feat: use ECR settings from argus-artifacts repo

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -64,8 +64,8 @@ runs:
         private_key: ${{ inputs.github_private_key }}
     - uses: actions/checkout@v4
       with:
-        repository: chanzuckerberg/core-platform-settings
-        path: core-platform-settings
+        repository: chanzuckerberg/argus-artifacts
+        path: argus-artifacts
         token: ${{ steps.generate_token.outputs.token }}
     - name: ECR Metadata
       id: ecr_metadata
@@ -89,8 +89,8 @@ runs:
       uses: int128/create-ecr-repository-action@v1
       with:
         repository: ${{ steps.ecr_metadata.outputs.ECR_REPO_NAME }}
-        lifecycle-policy: core-platform-settings/ecr/lifecycle-policy.json
-        repository-policy: core-platform-settings/ecr/repository-policy.json
+        lifecycle-policy: argus-artifacts/settings/ecr/lifecycle-policy.json
+        repository-policy: argus-artifacts/settings/ecr/repository-policy.json
     - name: Build And Push
       uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@74d720a183006c0fe0a82f52475befed7d992888
       with:

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -219,7 +219,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@v3.4.1
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@5c525e1a8eca45deeadd10d44727ddb2c653dadd
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}


### PR DESCRIPTION
core-platform-settings can't be used from the biohub org so these files have been migrated to the argus-artifacts repo