### PR TITLE
feat: remove old vulnerability comments when adding new vulnerability report comment

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -111,7 +111,7 @@ runs:
         secret-files: ${{ inputs.secret_files }}
         load: true
     - name: Scan for vulnerabilities
-      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@CCIE-4104-comment-replacement-in-container-scanning
+      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@a8769e107f2f0d6377933835baaa370a60295724
       id: scan
       with:
         image_name: ${{ inputs.image_name }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -111,8 +111,9 @@ runs:
         secret-files: ${{ inputs.secret_files }}
         load: true
     - name: Scan for vulnerabilities
-      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@193e90c0872c379105b55b1d02cf55e9992f6f16
+      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@dcbf86c28e42fc41ed13818813d57dcb34dad3c0
       id: scan
       with:
+        image_name: ${{ inputs.image_name }}
         image_uri: ${{ steps.create_ecr_repo.outputs.repository-uri }}:${{ inputs.image_tag }}
         fail_on_vulnerabilities: ${{ inputs.fail_on_vulnerabilities }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -111,7 +111,7 @@ runs:
         secret-files: ${{ inputs.secret_files }}
         load: true
     - name: Scan for vulnerabilities
-      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@dcbf86c28e42fc41ed13818813d57dcb34dad3c0
+      uses: chanzuckerberg/github-actions/.github/actions/container-scanning@CCIE-4104-comment-replacement-in-container-scanning
       id: scan
       with:
         image_name: ${{ inputs.image_name }}

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -73,20 +73,27 @@ runs:
         script: |
           let issueNumber;
           if (context.issue.number) {
+            console.log("...using issue number from context:", context.issue.number);
             // use issue number from context if present
             issueNumber = context.issue.number;
           } else {
             // Otherwise use issue number from commit
-            issueNumber = (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0].number;
+            listPullRequestsAssociatedWithCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            console.log("...using issue number from commit:", JSON.stringify(listPullRequestsAssociatedWithCommit, null, 2));
+            issueNumber = listPullRequestsAssociatedWithCommit.data[0].number;
+            // issueNumber = (
+            //   await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            //     commit_sha: context.sha,
+            //     owner: context.repo.owner,
+            //     repo: context.repo.repo,
+            //   })
+            // ).data[0].number;
           }
           if (!issueNumber) {
-            console.log('Could not find issue number');
             core.warning('Could not find issue number');
             return;
           }

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -73,7 +73,6 @@ runs:
         script: |
           let issueNumber;
           if (context.issue.number) {
-            console.log("...using issue number from context:", context.issue.number);
             // use issue number from context if present
             issueNumber = context.issue.number;
           } else {
@@ -84,7 +83,6 @@ runs:
               repo: context.repo.repo,
             });
             if (pullRequestsAssociatedWithCommit.data.length > 0) {
-              console.log("...using issue number from commit:", pullRequestsAssociatedWithCommit.data[0].number);
               issueNumber = pullRequestsAssociatedWithCommit.data[0].number;
             }
           }

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -85,6 +85,11 @@ runs:
               })
             ).data[0].number;
           }
+          if (!issueNumber) {
+            console.log('Could not find issue number');
+            core.warning('Could not find issue number');
+            return;
+          }
 
           // try to delete old comments about vulnerabilities
           const ownerAndRepo = '${{ github.repository }}';
@@ -92,7 +97,7 @@ runs:
           const { data: comments } = await github.rest.issues.listComments({
             owner,
             repo,
-            issue_number: ${{ github.event.pull_request.number }},
+            issue_number: issueNumber,
           });
           const commentHeader = ':rotating_light: **Vulnerabilities found in ${{ inputs.image_name }} image**: ${{ steps.ecr_metadata.outputs.IMAGE_URI }} :rotating_light:';
           for (let comment of comments) {

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -96,7 +96,7 @@ runs:
           });
           const commentHeader = ':rotating_light: **Vulnerabilities found in ${{ inputs.image_name }} image**: ${{ steps.ecr_metadata.outputs.IMAGE_URI }} :rotating_light:';
           for (let comment of comments) {
-            if (comment.body === noJiraIssueBody && comment.user.type === 'Bot') {
+            if (comment.body.includes(commentHeader) && comment.user.type === 'Bot') {
               console.log('Found comment to delete:', JSON.stringify(comment, null, 2));
               await github.rest.issues.deleteComment({
                 owner,

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -78,20 +78,15 @@ runs:
             issueNumber = context.issue.number;
           } else {
             // Otherwise use issue number from commit
-            listPullRequestsAssociatedWithCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            pullRequestsAssociatedWithCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               commit_sha: context.sha,
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            console.log("...using issue number from commit:", JSON.stringify(listPullRequestsAssociatedWithCommit, null, 2));
-            issueNumber = listPullRequestsAssociatedWithCommit.data[0].number;
-            // issueNumber = (
-            //   await github.rest.repos.listPullRequestsAssociatedWithCommit({
-            //     commit_sha: context.sha,
-            //     owner: context.repo.owner,
-            //     repo: context.repo.repo,
-            //   })
-            // ).data[0].number;
+            if (pullRequestsAssociatedWithCommit.data.length > 0) {
+              console.log("...using issue number from commit:", pullRequestsAssociatedWithCommit.data[0].number);
+              issueNumber = pullRequestsAssociatedWithCommit.data[0].number;
+            }
           }
           if (!issueNumber) {
             core.warning('Could not find issue number');

--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -1,6 +1,9 @@
 name: Container Scanning
 description: 'A GitHub Action to scan a container image for security vulnerabilities that follows CZI Best Practices'
 inputs:
+  image_name:
+    description: "name of the image being scanned"
+    required: true
   image_uri:
     description: 'which image to scan'
     required: true
@@ -82,8 +85,30 @@ runs:
               })
             ).data[0].number;
           }
+
+          // try to delete old comments about vulnerabilities
+          const ownerAndRepo = '${{ github.repository }}';
+          const [owner, repo] = ownerAndRepo.split('/');
+          const { data: comments } = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: ${{ github.event.pull_request.number }},
+          });
+          const commentHeader = ':rotating_light: **Vulnerabilities found in ${{ inputs.image_name }} image**: ${{ steps.ecr_metadata.outputs.IMAGE_URI }} :rotating_light:';
+          for (let comment of comments) {
+            if (comment.body === noJiraIssueBody && comment.user.type === 'Bot') {
+              console.log('Found comment to delete:', JSON.stringify(comment, null, 2));
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+              });
+            }
+          }
+
+          // create a new comment with the vulnerability information
           const body = `
-          :rotating_light: **Vulnerabilities found in image**: ${{ steps.ecr_metadata.outputs.IMAGE_URI }} :rotating_light:
+          ${commentHeader}
           Please review the vulnerabilities found in the image and take appropriate action:
           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           `;

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -226,7 +226,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@CCIE-4104-comment-replacement-in-container-scanning
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@5523f4a1eaf33eb6a6b64fb7523c8e6c7396dc98
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -226,7 +226,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@1b5e16bf4fc2f14eb80854a7e4fe9a3214a24e42
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@CCIE-4104-comment-replacement-in-container-scanning
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -226,7 +226,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@193e90c0872c379105b55b1d02cf55e9992f6f16
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@1b5e16bf4fc2f14eb80854a7e4fe9a3214a24e42
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}


### PR DESCRIPTION
Updates container-scanning action to remove old vulnerability report comments when adding a new comment to reduce noise on the PR

Tested in https://github.com/chanzuckerberg/argus/pull/830