### PR TITLE
fix: don't use docker image for yq

### DIFF
--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -79,18 +79,18 @@ runs:
           });
           const uniqueInfraDirPaths = [...new Set(infraDirPaths)];
           core.setOutput('infra_dir_paths', uniqueInfraDirPaths.join(' '));
-    - uses: mikefarah/yq@v4
+    - name: Update Manifest
       id: validate
-      with:
-        cmd: |
-          for env in ${{ steps.parse_envs.outputs.envs }}
+      shell: bash
+      run: |
+        for env in ${{ steps.parse_envs.outputs.envs }}
+        do
+          for infra_dir_path in ${{ steps.path.outputs.infra_dir_paths }}
           do
-            for infra_dir_path in ${{ steps.path.outputs.infra_dir_paths }}
-            do
-              yq -i '(.. | select(has("tag")) | select(.tag == "sha-*")).tag = "${{ inputs.image_tag }}"' ${infra_dir_path}/${env}/values.yaml
-              cat ${infra_dir_path}/${env}/values.yaml
-            done
+            yq -i '(.. | select(has("tag")) | select(.tag == "sha-*")).tag = "${{ inputs.image_tag }}"' ${infra_dir_path}/${env}/values.yaml
+            cat ${infra_dir_path}/${env}/values.yaml
           done
+        done
     - name: Update Argus manifests
       uses: EndBug/add-and-commit@v9
       with:

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -29,8 +29,8 @@ runs:
       uses: actions/create-github-app-token@v1
       id: generate_token
       with:
-        app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
-        private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
+        app-id: ${{ inputs.github_app_id }}
+        private-key: ${{ inputs.github_private_key }}
     - name: Determine checkout ref
       id: ref
       uses: actions/github-script@v7

--- a/.github/actions/argus-builder/manifest-update/action.yml
+++ b/.github/actions/argus-builder/manifest-update/action.yml
@@ -87,7 +87,7 @@ runs:
         do
           for infra_dir_path in ${{ steps.path.outputs.infra_dir_paths }}
           do
-            yq -i '(.. | select(has("tag")) | select(.tag == "sha-*")).tag = "${{ inputs.image_tag }}"' ${infra_dir_path}/${env}/values.yaml
+            yq eval -i '(.. | select(has("tag")) | select(.tag == "sha-*")).tag = "${{ inputs.image_tag }}"' ${infra_dir_path}/${env}/values.yaml
             cat ${infra_dir_path}/${env}/values.yaml
           done
         done

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -279,7 +279,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@f9e9bc2099df432bf3a931c7bda59a43be4940ad
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@4cc80cf42f69b005a3c06633dfa3475bfad47624
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -279,7 +279,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@4cc80cf42f69b005a3c06633dfa3475bfad47624
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@8729e23912af9292226bcb538f88e81fd3c9499c
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -279,7 +279,7 @@ jobs:
             console.log('Argus root dirs:', argusRootDirs);
             return argusRootDirs.join(',');
 
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@8729e23912af9292226bcb538f88e81fd3c9499c
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/manifest-update@003aae7f4a9e240dec80b6c1787a480cabda5fca
         if: steps.determine_manifests.outputs.result != ''
         with:
           envs: ${{ inputs.envs }}


### PR DESCRIPTION
Pulling the docker image for the `mikefarah/yq` step was getting rate limited by docker.io, this change is in tandem with these other PRs where we now install `yq` directly in the runner base image and no longer need to use the dockerized action step to run it:

- https://github.com/chanzuckerberg/gh-self-hosted-runners/pull/35
- https://github.com/chanzuckerberg/gh-self-hosted-runners/pull/36
- https://github.com/chanzuckerberg/gh-self-hosted-runners/pull/37