### PR TITLE
fix: expression injections in jira-validate-reference

### DIFF
--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -68,7 +68,7 @@ runs:
       uses: actions/github-script@v7
       env:
         HEADREF: ${{ github.head_ref }}
-        PRBODY: steps.getPullRequest.outputs.prBody
+        PRBODY: "abc" #steps.getPullRequest.outputs.prBody
         PRTITLE: steps.getPullRequest.outputs.prTitle
       with:
         script: |

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -68,12 +68,12 @@ runs:
       uses: actions/github-script@v7
       env:
         HEADREF: ${{ github.head_ref }}
-        PRBODY: "abc" #steps.getPullRequest.outputs.prBody
-        PRTITLE: steps.getPullRequest.outputs.prTitle
+        PRBODY: ${{ steps.getPullRequest.outputs.prBody }}
+        PRTITLE: ${{ steps.getPullRequest.outputs.prTitle }}
       with:
         script: |
-          const prBody = $PRBODY;
-          const prTitle = $PRTITLE;
+          const prBody = '$PRBODY';
+          const prTitle = '$PRTITLE';
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -31,10 +31,12 @@ runs:
     - name: Check If Job Should Run
       id: checkIfJobShouldRun
       uses: actions/github-script@v7
+      env:
+        HEADREF = ${{ github.head_ref }}
       with:
         script: |
           const skipBranchesRegex = new RegExp('${{ inputs.skipBranches }}');
-          const shouldRun = '${{ github.head_ref }}'.match(skipBranchesRegex) == null;
+          const shouldRun = '$HEADREF'.match(skipBranchesRegex) == null;
           if (shouldRun) {
             console.log('Job will run');
           } else {
@@ -64,15 +66,19 @@ runs:
       id: parseIssueRef
       if: steps.checkIfJobShouldRun.outputs.result == 'true'
       uses: actions/github-script@v7
+      env:
+        HEADREF = ${{ github.head_ref }}
+        PRBODY = ${{ steps.getPullRequest.outputs.prBody }}
+        PRTITLE =  ${{ steps.getPullRequest.outputs.prTitle }}
       with:
         script: |
-          const prBody = ${{ steps.getPullRequest.outputs.prBody }};
-          const prTitle = ${{ steps.getPullRequest.outputs.prTitle }};
+          const prBody = $PRBODY;
+          const prTitle = $PRTITLE;
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);
           [
-            { label: 'branch', value: '${{ github.head_ref }}' },
+            { label: 'branch', value: '$HEADREF' },
             { label: 'title', value: prTitle },
             { label: 'body', value: prBody },
           ].find(({label, value}) => {

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -74,6 +74,10 @@ runs:
         script: |
           const prBody = "$PRBODY";
           const prTitle = "$PRTITLE";
+          console.log("Show PRBODY");
+          console.log(prBody);
+          console.log("Show PRTITLE");
+          console.log(prTitle);
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);
@@ -93,7 +97,7 @@ runs:
 
           const ownerAndRepo = '${{ github.repository }}';
           const [owner, repo] = ownerAndRepo.split('/');
-          const noJiraIssueBody = `Title was ${{ prTitle }}. No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of ${{ inputs.projectKey }}-#### (eg: ${{ inputs.projectKey }}-1234) to the branch name, title, or body of your PR.`;
+          const noJiraIssueBody = `No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of ${{ inputs.projectKey }}-#### (eg: ${{ inputs.projectKey }}-1234) to the branch name, title, or body of your PR.`;
 
           const { data: comments } = await github.rest.issues.listComments({
             owner,

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -72,8 +72,8 @@ runs:
         PRTITLE: ${{ steps.getPullRequest.outputs.prTitle }}
       with:
         script: |
-          const prBody = '$PRBODY';
-          const prTitle = '$PRTITLE';
+          const prBody = "$PRBODY";
+          const prTitle = "$PRTITLE";
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -72,8 +72,11 @@ runs:
         PRTITLE: ${{ steps.getPullRequest.outputs.prTitle }}
       with:
         script: |
-          const prBody = "$PRBODY";
-          const prTitle = "$PRTITLE";
+          const { HEADREF, PRBODY, PRTITLE } = process.env
+
+          console.log(`Hello ${HEADREF} ${PRTITLE}`)
+          const prBody = PRBODY;
+          const prTitle = PRTITLE;
           console.log("Show PRBODY");
           console.log(prBody);
           console.log("Show PRTITLE");

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -93,7 +93,7 @@ runs:
 
           const ownerAndRepo = '${{ github.repository }}';
           const [owner, repo] = ownerAndRepo.split('/');
-          const noJiraIssueBody = `No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of ${{ inputs.projectKey }}-#### (eg: ${{ inputs.projectKey }}-1234) to the branch name, title, or body of your PR.`;
+          const noJiraIssueBody = `Title was ${{ prTitle }}. No Jira issue reference found in branch, title, or body of PR.\n\nPlease add a reference to a Jira issue in the form of ${{ inputs.projectKey }}-#### (eg: ${{ inputs.projectKey }}-1234) to the branch name, title, or body of your PR.`;
 
           const { data: comments } = await github.rest.issues.listComments({
             owner,

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -72,8 +72,8 @@ runs:
         PRTITLE: steps.getPullRequest.outputs.prTitle
       with:
         script: |
-          const prBody = PRBODY;
-          const prTitle = PRTITLE;
+          const prBody = $PRBODY;
+          const prTitle = $PRTITLE;
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -68,12 +68,10 @@ runs:
       uses: actions/github-script@v7
       env:
         HEADREF = ${{ github.head_ref }}
-        PRBODY = ${{ steps.getPullRequest.outputs.prBody }}
-        PRTITLE =  ${{ steps.getPullRequest.outputs.prTitle }}
       with:
         script: |
-          const prBody = $PRBODY;
-          const prTitle = $PRTITLE;
+          const prBody = ${{ steps.getPullRequest.outputs.prBody }};
+          const prTitle = ${{ steps.getPullRequest.outputs.prTitle }};
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -32,7 +32,7 @@ runs:
       id: checkIfJobShouldRun
       uses: actions/github-script@v7
       env:
-        HEADREF = ${{ github.head_ref }}
+        HEADREF: ${{ github.head_ref }}
       with:
         script: |
           const skipBranchesRegex = new RegExp('${{ inputs.skipBranches }}');
@@ -67,11 +67,13 @@ runs:
       if: steps.checkIfJobShouldRun.outputs.result == 'true'
       uses: actions/github-script@v7
       env:
-        HEADREF = ${{ github.head_ref }}
+        HEADREF: ${{ github.head_ref }}
+        PRBODY: steps.getPullRequest.outputs.prBody
+        PRTITLE: steps.getPullRequest.outputs.prTitle
       with:
         script: |
-          const prBody = ${{ steps.getPullRequest.outputs.prBody }};
-          const prTitle = ${{ steps.getPullRequest.outputs.prTitle }};
+          const prBody = PRBODY;
+          const prTitle = PRTITLE;
 
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -35,8 +35,9 @@ runs:
         HEADREF: ${{ github.head_ref }}
       with:
         script: |
+          const { HEADREF } = process.env
           const skipBranchesRegex = new RegExp('${{ inputs.skipBranches }}');
-          const shouldRun = '$HEADREF'.match(skipBranchesRegex) == null;
+          const shouldRun = HEADREF.match(skipBranchesRegex) == null;
           if (shouldRun) {
             console.log('Job will run');
           } else {
@@ -73,21 +74,12 @@ runs:
       with:
         script: |
           const { HEADREF, PRBODY, PRTITLE } = process.env
-
-          console.log(`Hello ${HEADREF} ${PRTITLE}`)
-          const prBody = PRBODY;
-          const prTitle = PRTITLE;
-          console.log("Show PRBODY");
-          console.log(prBody);
-          console.log("Show PRTITLE");
-          console.log(prTitle);
-
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);
           [
-            { label: 'branch', value: "$HEADREF" },
-            { label: 'title', value: prTitle },
-            { label: 'body', value: prBody },
+            { label: 'branch', value: HEADREF },
+            { label: 'title', value: PRTITLE },
+            { label: 'body', value: PRBODY },
           ].find(({label, value}) => {
             const match = value.match(issueRegex);
             if (match) {

--- a/.github/actions/jira-validate-reference/action.yaml
+++ b/.github/actions/jira-validate-reference/action.yaml
@@ -78,7 +78,7 @@ runs:
           let jiraIssueRef = null;
           const issueRegex = new RegExp(`${{ inputs.projectKey }}-\\d+`);
           [
-            { label: 'branch', value: '$HEADREF' },
+            { label: 'branch', value: "$HEADREF" },
             { label: 'title', value: prTitle },
             { label: 'body', value: prBody },
           ].find(({label, value}) => {


### PR DESCRIPTION
Use shell syntax to read inputs as  environment variable, which is described as the fix to prevent arbitrary injections in the codescanning result here: https://github.com/chanzuckerberg/github-actions/security/code-scanning/63

https://czi.atlassian.net/browse/CCIE-4242