### PR TITLE
fix: Remove flag from helm lint

### DIFF
--- a/.github/actions/helm-lint/action.yml
+++ b/.github/actions/helm-lint/action.yml
@@ -22,6 +22,6 @@ runs:
         set -o pipefail
 
         helm dependency update .
-        # produces `helm lint . --with-subcharts -f file1 -f file2` with values_files as file1,file2
-        helm lint . --with-subcharts $(echo "${{ inputs.values_files }}" | sed 's/,/ -f /g' | sed 's/^/-f /')
+        # produces `helm lint . -f file1 -f file2` with values_files as file1,file2
+        helm lint . $(echo "${{ inputs.values_files }}" | sed 's/,/ -f /g' | sed 's/^/-f /')
         yamllint .


### PR DESCRIPTION
There are some issues with this flag (https://github.com/helm/helm/issues/12798). With the flag, it wasn't able to properly lint the files. This action works without the flag. It is still able to find incorrect indentations/missing values.