### PR TITLE
fix: remove yamllint from helm-lint action

### DIFF
--- a/.github/actions/helm-lint/action.yml
+++ b/.github/actions/helm-lint/action.yml
@@ -24,4 +24,3 @@ runs:
         helm dependency update .
         # produces `helm lint . -f file1 -f file2` with values_files as file1,file2
         helm lint . $(echo "${{ inputs.values_files }}" | sed 's/,/ -f /g' | sed 's/^/-f /')
-        yamllint .


### PR DESCRIPTION
I tested to see if `helm lint` alone would catch yaml errors and it did so I think we can remove this