### PR TITLE
fix: container scanning - default to no threshold for low/info vulns

### DIFF
--- a/.github/actions/container-scanning/action.yml
+++ b/.github/actions/container-scanning/action.yml
@@ -29,11 +29,11 @@ inputs:
   low_threshold:
     description: 'number of low vulnerabilities that will cause the action to fail'
     required: false
-    default: "10"
+    default: "0"
   other_threshold:
     description: 'number of other vulnerabilities that will cause the action to fail'
     required: false
-    default: "10"
+    default: "0"
   fail_on_vulnerabilities:
     description: 'whether to fail the action if vulnerabilities are found'
     required: false


### PR DESCRIPTION
By default, we should not meet the failure threshold for any number of low or informational vulnerabilities. Currently, unless these are manually set to '0', any low or other vulns will trigger the threshold.