### PR TITLE
feat: mock out the argus/argo injected data so linter can work with dynamic CRDs

### DIFF
--- a/.github/actions/helm-lint/action.yml
+++ b/.github/actions/helm-lint/action.yml
@@ -23,4 +23,17 @@ runs:
 
         helm dependency update .
         # produces `helm lint . -f file1 -f file2` with values_files as file1,file2
-        helm lint . $(echo "${{ inputs.values_files }}" | sed 's/,/ -f /g' | sed 's/^/-f /')
+        helm lint . $(echo "${{ inputs.values_files }}" | sed 's/,/ -f /g' | sed 's/^/-f /') \
+          --set global.argoBuildEnv.appName=mockappname \
+          --set global.argoBuildEnv.appNamespace=mocknamespace \
+          --set global.argoBuildEnv.appRevision=0.0.0 \
+          --set global.argoBuildEnv.appRevisionShort=mockrevshort \
+          --set global.argoBuildEnv.appRevisionShort8=mockrev8 \
+          --set global.argoBuildEnv.appSourcePath=mocksourcepath \
+          --set global.argoBuildEnv.appSourceRepoUrl=mocksourcerepourl \
+          --set global.argoBuildEnv.appSourceTargetRevision=mocktargetrevision \
+          --set global.argusMetadata.appName=mockappname \
+          --set global.argusMetadata.appNamespace=mocknamespace \
+          --set global.argusMetadata.stackName=mockstackname \
+          --set global.argusMetadata.repoName=mockreponame \
+          --set global.argusMetadata.repoOwner=mockrepoowner


### PR DESCRIPTION
## Summary

If someone was creating a CRD in their Argus deployment, for example a grafana dashboard, and the CRD contained dynamic values such as the stack name, the CI helm linter would not work because it would be missing these metadata fields. This PR mocks them out so that the linter will have this information when it is run during the GH action.

For apps that are using this action, but aren't argus apps, I don't think this will affect them.

## References

* https://github.com/chanzuckerberg/argus-example-app/actions/runs/17558933053/job/49870505768?pr=291
* https://github.com/chanzuckerberg/edu-kg-mcp-servers/actions/runs/17558754906/job/49869573353?pr=79

## Tested

* https://github.com/chanzuckerberg/argus-example-app/actions/runs/17560730458/job/49876167148?pr=291