### PR TITLE
fix: use the cache from prod/staging argus builds (#441)

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -84,7 +84,7 @@ runs:
         echo "Current dir: $(pwd)"
         echo "Changing to context dir: $(dirname ${{ inputs.context }})"
         cd $(dirname ${{ inputs.context }})
-        RELEASE_PLEASE_BRANCHES=$(for i in $(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true); do echo -n "$i,"; done)
+        RELEASE_PLEASE_BRANCHES=$(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true)
         echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Calculate Cache-From
       id: cache-from
@@ -95,7 +95,7 @@ runs:
         script: |
           let cacheFrom = [
             "${{ steps.refs.outputs.headRef }}",
-            ...process.env.RELEASE_PLEASE_BRANCHES.split(",").filter(Boolean)
+            ...process.env.RELEASE_PLEASE_BRANCHES.split("\n").filter(Boolean)
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -77,25 +77,13 @@ runs:
     - name: Calculate Branch and Base Names
       id: refs
       uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.4.0
-    - name: Calculate all the release-please branches
-      id: release-please-branches
-      shell: bash
-      run: |
-        echo "Current dir: $(pwd)"
-        echo "Changing to context dir: $(dirname ${{ inputs.context }})"
-        cd $(dirname ${{ inputs.context }})
-        RELEASE_PLEASE_BRANCHES=$(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true)
-        echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Calculate Cache-From
       id: cache-from
       uses: actions/github-script@v7
-      env:
-        RELEASE_PLEASE_BRANCHES: ${{ steps.release-please-branches.outputs.RELEASE_PLEASE_BRANCHES }}
       with:
         script: |
           let cacheFrom = [
             "${{ steps.refs.outputs.headRef }}",
-            ...process.env.RELEASE_PLEASE_BRANCHES.split("\n").filter(Boolean)
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);


### PR DESCRIPTION
This reverts commit 09eb2e44cb47517ee9b380d26f37b2f03aa69bf2.

## Summary

I think what was happening was two cache-from statements were colliding. Sometimes it would pick the release-please and sometimes it would pick your branch. When it picked the release-please one and had a cache miss, some of the layers would get cached further down the line (like in a multi-stage build), but they matched the wrong branch. 