### PR TITLE
feat: switch cache from inline to registry

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -122,7 +122,6 @@ runs:
         custom_tag: ${{ inputs.image_tag }}
         platforms: ${{ inputs.platform }}
         build_args: |
-          IMAGE_TAG=${{ inputs.image_tag }}
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret_files }}
         load: ${{ inputs.enable_vuln_container_scan }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -113,7 +113,7 @@ runs:
         lifecycle-policy: argus-artifacts/settings/ecr/lifecycle-policy.json
         repository-policy: argus-artifacts/settings/ecr/repository-policy.json
     - name: Build And Push
-      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@v6
+      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@heathj/experiment
       with:
         dockerfile: ${{ github.event.repository.name }}/${{ inputs.dockerfile }}
         context: ${{ github.event.repository.name }}/${{ inputs.context }}
@@ -125,7 +125,7 @@ runs:
           IMAGE_TAG=${{ inputs.image_tag }}
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret_files }}
-        load: true
+        load: ${{ inputs.enable_vuln_container_scan }}
     - name: Scan for vulnerabilities
       if: ${{ inputs.enable_vuln_container_scan == 'true' }}
       uses: chanzuckerberg/github-actions/.github/actions/container-scanning@v6

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -113,7 +113,7 @@ runs:
         lifecycle-policy: argus-artifacts/settings/ecr/lifecycle-policy.json
         repository-policy: argus-artifacts/settings/ecr/repository-policy.json
     - name: Build And Push
-      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@heathj/experiment
+      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@v6
       with:
         dockerfile: ${{ github.event.repository.name }}/${{ inputs.dockerfile }}
         context: ${{ github.event.repository.name }}/${{ inputs.context }}
@@ -122,6 +122,7 @@ runs:
         custom_tag: ${{ inputs.image_tag }}
         platforms: ${{ inputs.platform }}
         build_args: |
+          IMAGE_TAG=${{ inputs.image_tag }}
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret_files }}
         load: ${{ inputs.enable_vuln_container_scan }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -47,11 +47,11 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: 533267185808.dkr.ecr.us-west-2.amazonaws.com
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v3
-    #   with:
-    #     image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
-    #     cache-image: false
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
+        cache-image: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -85,7 +85,7 @@ runs:
           let cacheFrom = [
             "${{ steps.refs.outputs.headRef }}"
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
-            .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:branch-${ref}`).join('\r\n');
+            .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:cache-branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);
           core.setOutput("cacheFrom", cacheFrom);
     - name: Build and push
@@ -96,10 +96,10 @@ runs:
         push: true
         load: ${{ inputs.load }}
         tags: ${{ steps.meta.outputs.tags }}
-        # labels: ${{ steps.meta.outputs.labels }}
-        cache-from: ${{ steps.cache-from.outputs.cacheFrom }}
+        cache-from: |
+          ${{ steps.cache-from.outputs.cacheFrom }}
         cache-to: |
-          type=inline,mode=max
+          ${{ steps.cache-from.outputs.cacheFrom }},mode=max
         build-args: |
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret-files }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -52,11 +52,11 @@ runs:
     #   with:
     #     image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
     #     cache-image: false
-    # - name: Set up Docker Buildx
-    #   uses: docker/setup-buildx-action@v3
-    #   with:
-    #     driver-opts: |
-    #       image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:master
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: |
+          image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:master
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -96,6 +96,7 @@ runs:
         push: true
         load: ${{ inputs.load }}
         tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         cache-from: |
           ${{ steps.cache-from.outputs.cacheFrom }}
         cache-to: |

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -47,16 +47,16 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: 533267185808.dkr.ecr.us-west-2.amazonaws.com
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
-        cache-image: false
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        driver-opts: |
-          image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:master
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v3
+    #   with:
+    #     image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
+    #     cache-image: false
+    # - name: Set up Docker Buildx
+    #   uses: docker/setup-buildx-action@v3
+    #   with:
+    #     driver-opts: |
+    #       image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:master
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -97,11 +97,10 @@ runs:
         push: true
         load: ${{ inputs.load }}
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        # TODO: this is not working as expected and breaking people's CI we think...
-        #cache-from: ${{ steps.cache-from.outputs.cacheFrom }}
-        #cache-to: |
-        #  type=inline,mode=max
+        # labels: ${{ steps.meta.outputs.labels }}
+        cache-from: ${{ steps.cache-from.outputs.cacheFrom }}
+        cache-to: |
+          type=inline,mode=max
         build-args: |
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret-files }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -83,7 +83,6 @@ runs:
       with:
         script: |
           let cacheFrom = [
-            "${{ steps.refs.outputs.baseRef }}",
             "${{ steps.refs.outputs.headRef }}"
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:branch-${ref}`).join('\r\n');

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -8,41 +8,41 @@ on:
         required: true
         type: string
       images:
-        description: 'JSON object specifying the images to build'
+        description: "JSON object specifying the images to build"
         required: true
         type: string
       path_filters:
-        description: 'Glob patterns to match against changed files in the repository, comma delimited'
+        description: "Glob patterns to match against changed files in the repository, comma delimited"
         required: false
         type: string
-        default: '**/*'
+        default: "**/*"
       branches_include:
-        description: 'Branch names to run this job on, supports wildcards, comma delimited'
+        description: "Branch names to run this job on, supports wildcards, comma delimited"
         required: false
         type: string
-        default: '*'
+        default: "*"
       branches_ignore:
-        description: 'Branch names to run this job on, supports wildcards, comma delimited'
+        description: "Branch names to run this job on, supports wildcards, comma delimited"
         required: false
         type: string
-        default: ''
+        default: ""
       force_update_manifests:
-        description: 'Whether to always update ArgoCD manifests after building the Docker images, regardless of which labels are present on the PR'
+        description: "Whether to always update ArgoCD manifests after building the Docker images, regardless of which labels are present on the PR"
         required: false
         type: boolean
         default: false
       fail_on_vulnerabilities:
-        description: 'whether to fail the action if vulnerabilities are found'
+        description: "whether to fail the action if vulnerabilities are found"
         required: false
         type: boolean
         default: true
       arm_runner_labels:
-        description: 'Runner label to use for steps that use an arm-based action runner'
+        description: "Runner label to use for steps that use an arm-based action runner"
         required: false
         type: string
         default: "['arm64-privileged']"
       amd_runner_labels:
-        description: 'Runner label to use for steps that use an amd64-based action runner'
+        description: "Runner label to use for steps that use an amd64-based action runner"
         required: false
         type: string
         default: "['amd64-privileged']"
@@ -52,7 +52,7 @@ on:
           If ANY of the labels are found on the PR, the manifest will be updated.
         required: false
         type: string
-        default: 'stack,stack-*'
+        default: "stack,stack-*"
       enable_vuln_container_scan:
         description: Opt in to scan containers with AWS inspector
         required: false
@@ -118,7 +118,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@v6
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@heathj/experiment
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@heathj/experiment
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@v6
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}


### PR DESCRIPTION
## Summary

This PR switches the cache style from inline to registry. Inline caching is good for really simple docker builds and usecases. However, it doesn't work with multistage builds (only the last stage is cached) and it seems to easily conflict with other cache-from layers. Switching to registry cache style allows us to cache all the multi-stage builds of a Dockerfile and in a separate location than the original image. Hopefully this should make our images smaller since they will no longer contain the cache layers.

## References

* https://docs.docker.com/build/cache/backends/registry/
* https://docs.docker.com/build/cache/backends/inline/
* https://github.com/chanzuckerberg/virtual-cells-platform/actions/runs/18024067121/job/51287660835 - test with registry cache (all layers cached when made an update to dockerfile)
* https://github.com/chanzuckerberg/virtual-cells-platform/actions/runs/18016664271/job/51273369240?pr=1454 - test with inline cache (frontend image's first stage is never cached and has to be rebuilt every time)