### PR TITLE
feat: add back in the release-please  branches in cache-from

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -113,7 +113,7 @@ runs:
         lifecycle-policy: argus-artifacts/settings/ecr/lifecycle-policy.json
         repository-policy: argus-artifacts/settings/ecr/repository-policy.json
     - name: Build And Push
-      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@v6
+      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@heathj/add-back-release-please-cache
       with:
         dockerfile: ${{ github.event.repository.name }}/${{ inputs.dockerfile }}
         context: ${{ github.event.repository.name }}/${{ inputs.context }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -112,6 +112,14 @@ runs:
         repository: ${{ steps.ecr_metadata.outputs.ECR_REPO_NAME }}
         lifecycle-policy: argus-artifacts/settings/ecr/lifecycle-policy.json
         repository-policy: argus-artifacts/settings/ecr/repository-policy.json
+    - name: Find Release Please Branches
+      id: release-please-branches
+      shell: bash
+      working-directory: ${{ github.event.repository.name }}
+      run: |
+        echo "Current dir: $(pwd)"
+        RELEASE_PLEASE_BRANCHES=$(for i in $(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true); do echo -n "$i,"; done)
+        echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Build And Push
       uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@heathj/add-back-release-please-cache
       with:
@@ -126,6 +134,7 @@ runs:
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret_files }}
         load: ${{ inputs.enable_vuln_container_scan }}
+        extra_cache_branches: ${{ steps.release-please-branches.outputs.RELEASE_PLEASE_BRANCHES }}
     - name: Scan for vulnerabilities
       if: ${{ inputs.enable_vuln_container_scan == 'true' }}
       uses: chanzuckerberg/github-actions/.github/actions/container-scanning@v6

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -121,7 +121,7 @@ runs:
         RELEASE_PLEASE_BRANCHES=$(for i in $(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true); do echo -n "$i,"; done)
         echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Build And Push
-      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@heathj/add-back-release-please-cache
+      uses: chanzuckerberg/github-actions/.github/actions/docker-build-push@v6
       with:
         dockerfile: ${{ github.event.repository.name }}/${{ inputs.dockerfile }}
         context: ${{ github.event.repository.name }}/${{ inputs.context }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -77,13 +77,25 @@ runs:
     - name: Calculate Branch and Base Names
       id: refs
       uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.4.0
+    - name: Calculate all the release-please branches
+      id: release-please-branches
+      shell: bash
+      run: |
+        echo "Current dir: $(pwd)"
+        echo "Changing to context dir: $(dirname ${{ inputs.context }})"
+        cd $(dirname ${{ inputs.context }})
+        RELEASE_PLEASE_BRANCHES=$(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true)
+        echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Calculate Cache-From
       id: cache-from
       uses: actions/github-script@v7
+      env:
+        RELEASE_PLEASE_BRANCHES: ${{ steps.release-please-branches.outputs.RELEASE_PLEASE_BRANCHES }}
       with:
         script: |
           let cacheFrom = [
             "${{ steps.refs.outputs.headRef }}"
+            ...process.env.RELEASE_PLEASE_BRANCHES.split("\n").filter(Boolean)
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:cache-branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:latest
+        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:v10.0.4-56
         cache-image: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -56,7 +56,7 @@ runs:
       uses: docker/setup-buildx-action@v3
       with:
         driver-opts: |
-          image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:master
+          image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:v0.25.0
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Load the image into the Docker daemon"
     required: false
     default: "false"
+  extra_cache_branches:
+    description: "Comma delimited list of extra cache branches to use after the current branch the build is happening on"
+    required: false
+    default: ""
 outputs:
   tags:
     description: "The tags we built and pushed"
@@ -77,29 +81,27 @@ runs:
     - name: Calculate Branch and Base Names
       id: refs
       uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.4.0
-    - name: Calculate all the release-please branches
-      id: release-please-branches
-      shell: bash
-      run: |
-        echo "Current dir: $(pwd)"
-        echo "Changing to context dir: $(dirname ${{ inputs.context }})"
-        cd $(dirname ${{ inputs.context }})
-        RELEASE_PLEASE_BRANCHES=$(for i in $(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true); do echo -n "$i,"; done)
-        echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
-    - name: Calculate Cache-From
-      id: cache-from
+    - name: Calculate cache-to and cache-from
+      id: cache
       uses: actions/github-script@v7
       env:
-        RELEASE_PLEASE_BRANCHES: ${{ steps.release-please-branches.outputs.RELEASE_PLEASE_BRANCHES }}
+        EXTRA_CACHE_BRANCHES: ${{ inputs.extra_cache_branches }}
       with:
         script: |
-          let cacheFrom = [
+          let caches = [
             "${{ steps.refs.outputs.headRef }}",
-            ...process.env.RELEASE_PLEASE_BRANCHES.split(",").filter(Boolean)
-          ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
-            .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:cache-branch-${ref}`).join('\r\n');
-          console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);
-          core.setOutput("cacheFrom", cacheFrom);
+            ...process.env.EXTRA_CACHE_BRANCHES.split(",").filter(Boolean),
+          ]
+          .map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
+          .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:cache-branch-${ref}`);
+
+          console.log(`Will use cached images from ${JSON.stringify(caches, null, 2)}`);
+
+          if (caches.length === 0) {
+            throw new Error("No cache branches found");
+          }
+          core.setOutput("cacheFrom", caches.join('\r\n'));
+          core.setOutput("cacheTo", caches[0])
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
@@ -110,9 +112,9 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: |
-          ${{ steps.cache-from.outputs.cacheFrom }}
+          ${{ steps.cache.outputs.cacheFrom }}
         cache-to: |
-          ${{ steps.cache-from.outputs.cacheFrom }},mode=max
+          ${{ steps.cache.outputs.cacheTo }},mode=max
         build-args: |
           ${{ inputs.build_args }}
         secret-files: ${{ inputs.secret-files }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -84,7 +84,7 @@ runs:
         echo "Current dir: $(pwd)"
         echo "Changing to context dir: $(dirname ${{ inputs.context }})"
         cd $(dirname ${{ inputs.context }})
-        RELEASE_PLEASE_BRANCHES=$(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true)
+        RELEASE_PLEASE_BRANCHES=$(for i in $(git branch -a | grep "release-please" | cut -d "/" -f 3 | grep "^release-please" || true); do echo -n "$i,"; done)
         echo "RELEASE_PLEASE_BRANCHES=${RELEASE_PLEASE_BRANCHES}" >> $GITHUB_OUTPUT
     - name: Calculate Cache-From
       id: cache-from
@@ -94,8 +94,8 @@ runs:
       with:
         script: |
           let cacheFrom = [
-            "${{ steps.refs.outputs.headRef }}"
-            ...process.env.RELEASE_PLEASE_BRANCHES.split("\n").filter(Boolean)
+            "${{ steps.refs.outputs.headRef }}",
+            ...process.env.RELEASE_PLEASE_BRANCHES.split(",").filter(Boolean)
           ].map(ref => ref.replaceAll(/[^a-zA-Z0-9-_\.]+/g, "-"))
             .map(ref => `type=registry,ref=${{ inputs.registry }}/${{ inputs.name }}:cache-branch-${ref}`).join('\r\n');
           console.log(`Will use cached images from ${JSON.stringify(cacheFrom, null, 2)}`);

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:v10.0.4-56
+        image: 533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/tonistiigi/binfmt:qemu-v10.0.4-56
         cache-image: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@heathj/add-back-release-please-cache
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@v6
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}

--- a/.github/workflows/argus-docker-build.yaml
+++ b/.github/workflows/argus-docker-build.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           script: |
             core.info(`Image to build: ${{ toJson(matrix.image) }}`);
-      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@v6
+      - uses: chanzuckerberg/github-actions/.github/actions/argus-builder/docker-build@heathj/add-back-release-please-cache
         if: matrix.image.should_build == true
         with:
           image_name: ${{ matrix.image.name }}


### PR DESCRIPTION
## Summary

Curious if the bug will return now that we are using registry cache. I have pinned the buildx builder to the latest stable branch and opened a ticket with buildx. The caching error was only happening in the latest version, which apparently is not released yet. Probably safe to not use it and just pin to the latest stable release instead. Also, the registry caching seems to be working better.

## Tests

* https://github.com/chanzuckerberg/argus-example-app/actions/runs/18176845306/attempts/1?pr=294
* https://github.com/moby/buildkit/issues/6256