### PR TITLE
feat: release-please preserve_files enhancements

### DIFF
--- a/.github/actions/release-please-semvar/README.md
+++ b/.github/actions/release-please-semvar/README.md
@@ -37,6 +37,8 @@ any commits added by other automations (e.g., Docker image tag updates). The
 `preserve_files` input lets you specify files that should be restored from the
 pre-force-push state of the branch.
 
+Comma-separated:
+
 ```yaml
       - uses: chanzuckerberg/github-actions/.github/actions/release-please-semvar@main
         with:
@@ -44,8 +46,26 @@ pre-force-push state of the branch.
             preserve_files: '.infra/prod/values.yaml,.infra/staging/values.yaml'
 ```
 
-`preserve_files` is a comma-separated list of file paths. After release-please
-runs, the action will check out the release branch, restore each listed file from
-the commit that existed before the force push, and push a fixup commit. If a file
-didn't exist on the branch prior to the force push (e.g., the automation hasn't
-run yet), it is silently skipped.
+Newline-separated (YAML multiline):
+
+```yaml
+      - uses: chanzuckerberg/github-actions/.github/actions/release-please-semvar@main
+        with:
+            app_token: ${{ steps.generate_token.outputs.token }}
+            preserve_files: |
+              .infra/prod/values.yaml
+              .infra/staging/values.yaml
+```
+
+With glob patterns:
+
+```yaml
+            preserve_files: '.infra/*/values.yaml'
+```
+
+`preserve_files` accepts file paths or glob patterns (`*`, `?`, `[]`), separated
+by commas, newlines, or a mix of both. Patterns are expanded against the old
+branch's file tree. After release-please runs, matched files are carried forward
+via 3-way merge so only branch-specific edits are preserved. If a pattern matches
+no files on the old branch (e.g., the automation hasn't run yet), it is silently
+skipped.

--- a/.github/actions/release-please-semvar/README.md
+++ b/.github/actions/release-please-semvar/README.md
@@ -34,8 +34,8 @@ or set the corresponding setting in the release please config file.
 
 `release-please` force-pushes its release branch every time it runs, which overwrites
 any commits added by other automations (e.g., Docker image tag updates). The
-`preserve_files` input lets you specify files that should be restored from the
-pre-force-push state of the branch.
+`preserve_files` input lets you specify files whose automation-made changes should
+be carried forward onto the new release branch.
 
 Comma-separated:
 
@@ -57,15 +57,21 @@ Newline-separated (YAML multiline):
               .infra/staging/values.yaml
 ```
 
-With glob patterns:
+With glob patterns (note: `*` matches a single path segment, not recursive):
 
 ```yaml
-            preserve_files: '.infra/*/values.yaml'
+            preserve_files: '*/.infra/staging/values.yaml'
 ```
 
 `preserve_files` accepts file paths or glob patterns (`*`, `?`, `[]`), separated
 by commas, newlines, or a mix of both. Patterns are expanded against the old
-branch's file tree. After release-please runs, matched files are carried forward
-via 3-way merge so only branch-specific edits are preserved. If a pattern matches
-no files on the old branch (e.g., the automation hasn't run yet), it is silently
-skipped.
+branch's file tree.
+
+After release-please runs, the action computes the diff between the old branch's
+base commit and the old branch tip (i.e., exactly what the automation changed),
+then applies that patch to the new release branch with `git apply`. Only the
+automation's specific edits are replayed -- other changes in the same file (e.g.,
+new env vars merged from main) are never touched. If the patch does not apply
+cleanly, the branch is left as-is and a warning is logged. If a pattern matches
+no files on the old branch (e.g., the automation hasn't run yet on this release
+cycle), it is silently skipped.

--- a/.github/actions/release-please-semvar/README.md
+++ b/.github/actions/release-please-semvar/README.md
@@ -69,9 +69,19 @@ branch's file tree.
 
 After release-please runs, the action computes the diff between the old branch's
 base commit and the old branch tip (i.e., exactly what the automation changed),
-then applies that patch to the new release branch with `git apply`. Only the
-automation's specific edits are replayed -- other changes in the same file (e.g.,
-new env vars merged from main) are never touched. If the patch does not apply
-cleanly, the branch is left as-is and a warning is logged. If a pattern matches
-no files on the old branch (e.g., the automation hasn't run yet on this release
-cycle), it is silently skipped.
+then replays those edits onto the new release branch. Only the automation's
+specific scalar-value changes are applied -- other content in the same file (e.g.,
+new env vars merged from main) is never touched. If a pattern matches no files on
+the old branch (e.g., the automation hasn't run yet on this release cycle), it is
+silently skipped.
+
+To avoid double-triggering downstream workflows, release-please internally uses
+`GITHUB_TOKEN` (whose pushes are silent) when `preserve_files` is set. The
+preserved files are then folded into release-please's commit via `git commit
+--amend` and force-pushed with the app token in a single push, so path-filtered
+workflows trigger exactly once with the complete changeset.
+
+> **Note:** Callers must ensure the workflow's `GITHUB_TOKEN` has
+> `contents: write` and `pull-requests: write` permissions. This is the default
+> for most repositories but may need to be declared explicitly if the workflow
+> uses a restrictive `permissions:` block.

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -154,7 +154,7 @@ runs:
             // restricted to the matched files, then apply it to the current branch.
             // This surgically applies only the automation's edits without touching
             // anything else in the file (env vars, other keys, etc.).
-            const patchArgs = ['diff', oldBase, oldSha, '--', ...files];
+            const patchArgs = ['diff', '-U0', oldBase, oldSha, '--', ...files];
             const patchResult = await git(patchArgs);
             const patch = patchResult.stdout;
 

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -43,63 +43,59 @@ runs:
       with:
         token: ${{ inputs.app_token }}
         include-component-in-tag: ${{ inputs.include_component_in_tag }}
-    - name: resolve release branch
+    - name: resolve release branches
       if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
       id: resolve_restore
       uses: actions/github-script@v8
       env:
         BRANCH_SHAS: ${{ steps.snapshot.outputs.branch_shas }}
-        PR_JSON: ${{ steps.release.outputs.pr }}
+        PRS_JSON: ${{ steps.release.outputs.prs }}
       with:
         script: |
           const branchShas = JSON.parse(process.env.BRANCH_SHAS || '{}');
-          let pr;
+          let prs;
           try {
-            pr = JSON.parse(process.env.PR_JSON);
+            prs = JSON.parse(process.env.PRS_JSON || '[]');
           } catch {
-            core.info('Could not parse PR output, skipping restore');
+            core.info('Could not parse prs output, skipping restore');
             core.setOutput('should_restore', 'false');
+            core.setOutput('restore_targets', '[]');
             return;
           }
 
-          const branch = pr.headBranchName;
-          if (!branch) {
-            core.info('Could not determine release branch name from pr output, skipping');
-            core.setOutput('should_restore', 'false');
-            return;
+          const targets = [];
+          for (const pr of prs) {
+            const branch = pr.headBranchName;
+            if (!branch) {
+              core.info('PR missing headBranchName, skipping');
+              continue;
+            }
+            const oldSha = branchShas[branch];
+            if (!oldSha) {
+              core.info(`No previous SHA found for ${branch} (new branch), skipping`);
+              continue;
+            }
+            core.info(`Queued restore: branch=${branch}, oldSha=${oldSha}`);
+            targets.push({ branch, oldSha });
           }
 
-          const oldSha = branchShas[branch];
-          if (!oldSha) {
-            core.info(`No previous SHA found for ${branch} (new branch), skipping`);
-            core.setOutput('should_restore', 'false');
-            return;
-          }
-
-          core.info(`Branch: ${branch}, Old SHA: ${oldSha}`);
-          core.setOutput('branch', branch);
-          core.setOutput('old_sha', oldSha);
-          core.setOutput('should_restore', 'true');
-    - name: checkout release branch
-      if: ${{ steps.resolve_restore.outputs.should_restore == 'true' }}
-      uses: actions/checkout@v6
+          core.setOutput('restore_targets', JSON.stringify(targets));
+          core.setOutput('should_restore', targets.length > 0 ? 'true' : 'false');
+    - uses: actions/checkout@v6
       with:
-        ref: ${{ steps.resolve_restore.outputs.branch }}
-        token: ${{ inputs.app_token }}
+        persist-credentials: true
         fetch-depth: 0
     - name: restore preserved files
       if: ${{ steps.resolve_restore.outputs.should_restore == 'true' }}
       uses: actions/github-script@v8
       env:
-        OLD_SHA: ${{ steps.resolve_restore.outputs.old_sha }}
-        BRANCH: ${{ steps.resolve_restore.outputs.branch }}
+        RESTORE_TARGETS: ${{ steps.resolve_restore.outputs.restore_targets }}
         PRESERVE_FILES: ${{ inputs.preserve_files }}
       with:
         script: |
           const fs = require('fs');
           const path = require('path');
-          const oldSha = process.env.OLD_SHA;
-          const branch = process.env.BRANCH;
+          const targets = JSON.parse(process.env.RESTORE_TARGETS || '[]');
           const preserveFiles = process.env.PRESERVE_FILES;
 
           function globToRegex(pattern) {
@@ -108,108 +104,106 @@ runs:
           }
 
           async function git(args, opts = {}) {
-            const result = await exec.getExecOutput('git', args, {
+            return exec.getExecOutput('git', args, {
               ignoreReturnCode: opts.ignoreReturnCode || false,
               silent: opts.silent || false,
             });
-            return result;
           }
 
-          core.info(`Merging branch-specific changes from ${oldSha} onto ${branch}`);
-
-          await exec.exec('git', ['fetch', 'origin', oldSha]);
-          await exec.exec('git', ['config', 'user.name', 'czi-github-helper[bot]']);
-          await exec.exec('git', ['config', 'user.email', '95879977+czi-github-helper[bot]@users.noreply.github.com']);
-
-          const mergeBaseResult = await git(['merge-base', oldSha, 'HEAD']);
-          const oldBase = mergeBaseResult.stdout.trim();
-          core.info(`Old branch base (merge-base with current HEAD): ${oldBase}`);
-
-          // Parse patterns: split on commas and newlines, trim
+          // Parse patterns once -- same for all branches
           const patterns = preserveFiles
             .split(/[,\n]/)
             .map(s => s.trim())
             .filter(Boolean);
 
-          // Get file tree at old SHA
-          const treeResult = await git(['ls-tree', '-r', '--name-only', oldSha]);
-          const allOldFiles = treeResult.stdout.trim().split('\n').filter(Boolean);
+          await exec.exec('git', ['config', 'user.name', 'czi-github-helper[bot]']);
+          await exec.exec('git', ['config', 'user.email', '95879977+czi-github-helper[bot]@users.noreply.github.com']);
 
-          // Expand globs and deduplicate
-          const resolvedSet = new Set();
-          for (const pattern of patterns) {
-            const regex = globToRegex(pattern);
-            let matched = false;
-            for (const file of allOldFiles) {
-              if (regex.test(file)) {
-                resolvedSet.add(file);
-                matched = true;
+          for (const { branch, oldSha } of targets) {
+            core.info(`Processing branch ${branch} (old SHA: ${oldSha})`);
+
+            await exec.exec('git', ['fetch', 'origin', oldSha]);
+            await exec.exec('git', ['fetch', 'origin', branch]);
+            await exec.exec('git', ['checkout', branch]);
+
+            const mergeBaseResult = await git(['merge-base', oldSha, 'HEAD']);
+            const oldBase = mergeBaseResult.stdout.trim();
+            core.info(`Old branch base (merge-base with current HEAD): ${oldBase}`);
+
+            // Get file tree at old SHA and expand globs
+            const treeResult = await git(['ls-tree', '-r', '--name-only', oldSha]);
+            const allOldFiles = treeResult.stdout.trim().split('\n').filter(Boolean);
+
+            const resolvedSet = new Set();
+            for (const pattern of patterns) {
+              const regex = globToRegex(pattern);
+              let matched = false;
+              for (const file of allOldFiles) {
+                if (regex.test(file)) {
+                  resolvedSet.add(file);
+                  matched = true;
+                }
+              }
+              if (!matched) {
+                core.info(`Pattern '${pattern}' matched no files at ${oldSha}, skipping`);
               }
             }
-            if (!matched) {
-              core.info(`Pattern '${pattern}' matched no files at ${oldSha}, skipping`);
+
+            const files = [...resolvedSet].sort();
+            core.info(`Resolved ${files.length} file(s) to check: ${files.join(', ')}`);
+
+            let restored = 0;
+            for (const file of files) {
+              const diffResult = await git(
+                ['diff', '--quiet', oldBase, oldSha, '--', file],
+                { ignoreReturnCode: true }
+              );
+              if (diffResult.exitCode === 0) {
+                core.info(`File ${file} unchanged between old base and old branch tip, nothing to carry forward`);
+                continue;
+              }
+
+              const dir = path.dirname(file);
+              if (dir !== '.') fs.mkdirSync(dir, { recursive: true });
+
+              const baseResult = await git(['show', `${oldBase}:${file}`], { ignoreReturnCode: true });
+              fs.writeFileSync(`${file}.base`, baseResult.exitCode === 0 ? baseResult.stdout : '');
+
+              const otherResult = await git(['show', `${oldSha}:${file}`]);
+              fs.writeFileSync(`${file}.other`, otherResult.stdout);
+
+              const currentContent = fs.existsSync(file) ? fs.readFileSync(file) : Buffer.from('');
+              fs.writeFileSync(`${file}.current`, currentContent);
+
+              const mergeResult = await exec.getExecOutput(
+                'git', ['merge-file', `${file}.current`, `${file}.base`, `${file}.other`],
+                { ignoreReturnCode: true }
+              );
+
+              fs.copyFileSync(`${file}.current`, file);
+              if (mergeResult.exitCode === 0) {
+                core.info(`3-way merged branch-specific changes for ${file}`);
+              } else {
+                core.warning(`Merge conflict in ${file}, applied with conflict markers — manual resolution may be needed`);
+              }
+
+              fs.unlinkSync(`${file}.base`);
+              fs.unlinkSync(`${file}.other`);
+              fs.unlinkSync(`${file}.current`);
+
+              await exec.exec('git', ['add', file]);
+              restored++;
             }
-          }
 
-          const files = [...resolvedSet].sort();
-          core.info(`Resolved ${files.length} file(s) to check: ${files.join(', ')}`);
-
-          let restored = 0;
-          for (const file of files) {
-            const diffResult = await git(
-              ['diff', '--quiet', oldBase, oldSha, '--', file],
-              { ignoreReturnCode: true }
-            );
-            if (diffResult.exitCode === 0) {
-              core.info(`File ${file} unchanged between old base and old branch tip, nothing to carry forward`);
-              continue;
-            }
-
-            const dir = path.dirname(file);
-            if (dir !== '.') {
-              fs.mkdirSync(dir, { recursive: true });
-            }
-
-            const baseResult = await git(['show', `${oldBase}:${file}`], { ignoreReturnCode: true });
-            fs.writeFileSync(`${file}.base`, baseResult.exitCode === 0 ? baseResult.stdout : '');
-
-            const otherResult = await git(['show', `${oldSha}:${file}`]);
-            fs.writeFileSync(`${file}.other`, otherResult.stdout);
-
-            const currentContent = fs.existsSync(file) ? fs.readFileSync(file) : Buffer.from('');
-            fs.writeFileSync(`${file}.current`, currentContent);
-
-            const mergeResult = await exec.getExecOutput(
-              'git', ['merge-file', `${file}.current`, `${file}.base`, `${file}.other`],
-              { ignoreReturnCode: true }
-            );
-
-            fs.copyFileSync(`${file}.current`, file);
-            if (mergeResult.exitCode === 0) {
-              core.info(`3-way merged branch-specific changes for ${file}`);
+            const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
+            if (restored > 0 && diffCheck.exitCode !== 0) {
+              await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
+              await exec.exec('git', ['push', 'origin', branch]);
+              core.info(`Pushed ${restored} file(s) with carried-forward changes to ${branch}`);
             } else {
-              core.warning(`Merge conflict in ${file}, applied with conflict markers — manual resolution may be needed`);
+              core.info(`No branch-specific changes needed carrying forward for ${branch}`);
             }
-
-            fs.unlinkSync(`${file}.base`);
-            fs.unlinkSync(`${file}.other`);
-            fs.unlinkSync(`${file}.current`);
-
-            await exec.exec('git', ['add', file]);
-            restored++;
           }
-
-          const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
-          if (restored > 0 && diffCheck.exitCode !== 0) {
-            await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
-            await exec.exec('git', ['push', 'origin', branch]);
-            core.info(`Pushed ${restored} file(s) with carried-forward changes to ${branch}`);
-          } else {
-            core.info('No branch-specific changes needed carrying forward');
-          }
-    - uses: actions/checkout@v6
-      with:
-          persist-credentials: true # used in subsequent action to git push
     - name: tag root major and minor versions
       shell: bash
       run: |

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -150,32 +150,97 @@ runs:
             const files = [...resolvedSet].sort();
             core.info(`Resolved ${files.length} file(s) to check: ${files.join(', ')}`);
 
-            // Build a patch of only what the automation changed (oldBase → oldSha)
-            // restricted to the matched files, then apply it to the current branch.
-            // This surgically applies only the automation's edits without touching
-            // anything else in the file (env vars, other keys, etc.).
-            const patchArgs = ['diff', '-U0', oldBase, oldSha, '--', ...files];
-            const patchResult = await git(patchArgs);
-            const patch = patchResult.stdout;
+            // Apply the automation's changes line-by-line onto the new branch file.
+            // This guarantees:
+            //   - Only lines the automation explicitly changed are touched
+            //   - All other content from the new branch (env vars, fields adjacent to
+            //     the changed line, etc.) is preserved unchanged
+            //   - When main also changed the same line, the automation's value wins
+            //     via YAML key-prefix matching
+            const fs = require('fs');
+            let restored = 0;
 
-            if (!patch.trim()) {
-              core.info(`No automation changes to carry forward for ${branch}`);
-            } else {
-              const applyResult = await exec.getExecOutput(
-                'git', ['apply', '--3way', '--index', '--whitespace=fix'],
-                { ignoreReturnCode: true, input: Buffer.from(patch) }
-              );
+            for (const file of files) {
+              const diffResult = await git(['diff', '-U0', oldBase, oldSha, '--', file]);
+              const diffText = diffResult.stdout;
 
-              if (applyResult.exitCode === 0) {
-                core.info(`Patch applied cleanly for ${branch}`);
-                await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
-                await exec.exec('git', ['push', 'origin', branch]);
-                core.info(`Pushed carried-forward changes to ${branch}`);
-              } else {
-                core.warning(`Patch did not apply cleanly for ${branch} — skipping to avoid broken state:\n${applyResult.stderr}`);
-                await exec.exec('git', ['checkout', '--', '.'], { ignoreReturnCode: true });
-                await exec.exec('git', ['reset', 'HEAD'], { ignoreReturnCode: true });
+              if (!diffText.trim()) {
+                core.info(`File ${file} unchanged between old base and old branch tip, nothing to carry forward`);
+                continue;
               }
+
+              // Parse the -U0 unified diff into hunks (removed/added line arrays)
+              const hunks = [];
+              let rem = [], add = [];
+              for (const line of diffText.split('\n')) {
+                if (line.startsWith('@@ ')) {
+                  if (rem.length || add.length) hunks.push({ rem: [...rem], add: [...add] });
+                  rem = []; add = [];
+                } else if (line.startsWith('-') && !line.startsWith('---')) {
+                  rem.push(line.slice(1));
+                } else if (line.startsWith('+') && !line.startsWith('+++')) {
+                  add.push(line.slice(1));
+                }
+              }
+              if (rem.length || add.length) hunks.push({ rem, add });
+
+              let content = fs.readFileSync(file, 'utf8');
+              let fileChanged = false;
+
+              for (const { rem, add } of hunks) {
+                if (rem.length !== 1 || add.length !== 1) {
+                  // Skip insertions, deletions, and multi-line rewrites — the automation
+                  // is expected to only update scalar values (e.g. image tag).
+                  const desc = `${rem.length} removed / ${add.length} added`;
+                  core.warning(`${file}: skipping non-scalar hunk (${desc}) — only single-line value replacements are supported`);
+                  continue;
+                }
+
+                const oldLine = rem[0];
+                const newLine = add[0];
+
+                if (content.includes(newLine)) {
+                  core.info(`${file}: already contains "${newLine.trim()}", skipping`);
+                } else if (content.includes(oldLine)) {
+                  // Common case: the line is still at its base value — replace directly.
+                  content = content.replaceAll(oldLine, newLine);
+                  core.info(`${file}: "${oldLine.trim()}" → "${newLine.trim()}"`);
+                  fileChanged = true;
+                } else {
+                  // Main also changed this line. Match by YAML key prefix so the
+                  // automation's value still wins for that specific key.
+                  const colonIdx = oldLine.indexOf(': ');
+                  if (colonIdx !== -1) {
+                    const prefix = oldLine.slice(0, colonIdx + 2);
+                    const esc = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                    const re = new RegExp(`^${esc}.+$`, 'm');
+                    if (re.test(content)) {
+                      content = content.replace(re, newLine);
+                      core.info(`${file}: key-prefix match "${prefix.trim()}" → "${newLine.trim()}"`);
+                      fileChanged = true;
+                    } else {
+                      core.warning(`${file}: could not locate line for "${oldLine.trim()}" — skipping`);
+                    }
+                  } else {
+                    core.warning(`${file}: no YAML key separator in "${oldLine.trim()}" — skipping`);
+                  }
+                }
+              }
+
+              if (fileChanged) {
+                fs.writeFileSync(file, content);
+                await exec.exec('git', ['add', file]);
+                restored++;
+              }
+            }
+
+            const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
+            if (restored > 0 && diffCheck.exitCode !== 0) {
+              await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
+              await exec.exec('git', ['push', 'origin', branch]);
+              core.info(`Pushed carried-forward changes to ${branch}`);
+            } else {
+              core.info(`No branch-specific changes needed carrying forward for ${branch}`);
             }
           }
     - name: tag root major and minor versions

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -41,7 +41,7 @@ runs:
       uses: googleapis/release-please-action@v4
       id: release
       with:
-        token: ${{ inputs.app_token }}
+        token: ${{ inputs.preserve_files != '' && github.token || inputs.app_token }}
         include-component-in-tag: ${{ inputs.include_component_in_tag }}
     - name: resolve release branches
       if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
@@ -83,9 +83,11 @@ runs:
           core.setOutput('should_restore', targets.length > 0 ? 'true' : 'false');
     - uses: actions/checkout@v6
       with:
+        token: ${{ inputs.app_token }}
         persist-credentials: true
         fetch-depth: 0
     - name: restore preserved files
+      id: restore_preserved_files
       if: ${{ steps.resolve_restore.outputs.should_restore == 'true' }}
       uses: actions/github-script@v8
       env:
@@ -117,6 +119,7 @@ runs:
           await exec.exec('git', ['config', 'user.name', 'czi-github-helper[bot]']);
           await exec.exec('git', ['config', 'user.email', '95879977+czi-github-helper[bot]@users.noreply.github.com']);
 
+          const pushedBranches = [];
           for (const { branch, oldSha } of targets) {
             core.info(`Processing branch ${branch} (old SHA: ${oldSha})`);
 
@@ -236,12 +239,48 @@ runs:
 
             const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
             if (restored > 0 && diffCheck.exitCode !== 0) {
-              await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
-              await exec.exec('git', ['push', 'origin', branch]);
+              await exec.exec('git', ['commit', '--amend', '--no-edit']);
+              await exec.exec('git', ['push', '--force-with-lease', 'origin', branch]);
               core.info(`Pushed carried-forward changes to ${branch}`);
+              pushedBranches.push(branch);
             } else {
               core.info(`No branch-specific changes needed carrying forward for ${branch}`);
             }
+          }
+          core.setOutput('pushed_branches', JSON.stringify(pushedBranches));
+    - name: trigger workflows on release branches without restore
+      id: trigger_workflows
+      if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
+      uses: actions/github-script@v8
+      env:
+        PRS_JSON: ${{ steps.release.outputs.prs }}
+        PUSHED_BRANCHES: ${{ steps.restore_preserved_files.outputs.pushed_branches }}
+      with:
+        script: |
+          let prs;
+          try {
+            prs = JSON.parse(process.env.PRS_JSON || '[]');
+          } catch {
+            core.info('Could not parse prs output, skipping trigger');
+            return;
+          }
+          const pushedBranches = new Set(JSON.parse(process.env.PUSHED_BRANCHES || '[]'));
+
+          await exec.exec('git', ['config', 'user.name', 'czi-github-helper[bot]']);
+          await exec.exec('git', ['config', 'user.email', '95879977+czi-github-helper[bot]@users.noreply.github.com']);
+
+          for (const pr of prs) {
+            const branch = pr.headBranchName;
+            if (!branch) continue;
+            if (pushedBranches.has(branch)) {
+              core.info(`Branch ${branch} already pushed by restore step, skipping`);
+              continue;
+            }
+            core.info(`No-op amend + force-push for ${branch} to trigger workflows`);
+            await exec.exec('git', ['fetch', 'origin', branch]);
+            await exec.exec('git', ['checkout', branch]);
+            await exec.exec('git', ['commit', '--amend', '--no-edit']);
+            await exec.exec('git', ['push', '--force-with-lease', 'origin', branch]);
           }
     - name: tag root major and minor versions
       shell: bash

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: false
   preserve_files:
-    description: 'File paths or glob patterns to carry forward after release-please force-pushes the release branch. Accepts comma-separated, newline-separated, or a mix of both. Globs (e.g. .infra/*/values.yaml) are expanded against the old branch tree. Changes are merged via 3-way merge so only branch-specific edits are preserved.'
+    description: 'File paths or glob patterns to carry forward after release-please force-pushes the release branch. Accepts comma-separated, newline-separated, or a mix of both. Globs (e.g. */.infra/values.yaml) are expanded against the old branch tree. Only the exact changes the automation made (diff between the old branch and its base) are applied to the new branch, so unrelated edits in the same file are never touched.'
     required: false
     default: ''
 runs:
@@ -93,8 +93,6 @@ runs:
         PRESERVE_FILES: ${{ inputs.preserve_files }}
       with:
         script: |
-          const fs = require('fs');
-          const path = require('path');
           const targets = JSON.parse(process.env.RESTORE_TARGETS || '[]');
           const preserveFiles = process.env.PRESERVE_FILES;
 
@@ -152,56 +150,31 @@ runs:
             const files = [...resolvedSet].sort();
             core.info(`Resolved ${files.length} file(s) to check: ${files.join(', ')}`);
 
-            let restored = 0;
-            for (const file of files) {
-              const diffResult = await git(
-                ['diff', '--quiet', oldBase, oldSha, '--', file],
-                { ignoreReturnCode: true }
-              );
-              if (diffResult.exitCode === 0) {
-                core.info(`File ${file} unchanged between old base and old branch tip, nothing to carry forward`);
-                continue;
-              }
+            // Build a patch of only what the automation changed (oldBase → oldSha)
+            // restricted to the matched files, then apply it to the current branch.
+            // This surgically applies only the automation's edits without touching
+            // anything else in the file (env vars, other keys, etc.).
+            const patchArgs = ['diff', oldBase, oldSha, '--', ...files];
+            const patchResult = await git(patchArgs);
+            const patch = patchResult.stdout;
 
-              const dir = path.dirname(file);
-              if (dir !== '.') fs.mkdirSync(dir, { recursive: true });
-
-              const baseResult = await git(['show', `${oldBase}:${file}`], { ignoreReturnCode: true });
-              fs.writeFileSync(`${file}.base`, baseResult.exitCode === 0 ? baseResult.stdout : '');
-
-              const otherResult = await git(['show', `${oldSha}:${file}`]);
-              fs.writeFileSync(`${file}.other`, otherResult.stdout);
-
-              const currentContent = fs.existsSync(file) ? fs.readFileSync(file) : Buffer.from('');
-              fs.writeFileSync(`${file}.current`, currentContent);
-
-              const mergeResult = await exec.getExecOutput(
-                'git', ['merge-file', `${file}.current`, `${file}.base`, `${file}.other`],
-                { ignoreReturnCode: true }
-              );
-
-              fs.copyFileSync(`${file}.current`, file);
-              if (mergeResult.exitCode === 0) {
-                core.info(`3-way merged branch-specific changes for ${file}`);
-              } else {
-                core.warning(`Merge conflict in ${file}, applied with conflict markers — manual resolution may be needed`);
-              }
-
-              fs.unlinkSync(`${file}.base`);
-              fs.unlinkSync(`${file}.other`);
-              fs.unlinkSync(`${file}.current`);
-
-              await exec.exec('git', ['add', file]);
-              restored++;
-            }
-
-            const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
-            if (restored > 0 && diffCheck.exitCode !== 0) {
-              await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
-              await exec.exec('git', ['push', 'origin', branch]);
-              core.info(`Pushed ${restored} file(s) with carried-forward changes to ${branch}`);
+            if (!patch.trim()) {
+              core.info(`No automation changes to carry forward for ${branch}`);
             } else {
-              core.info(`No branch-specific changes needed carrying forward for ${branch}`);
+              const applyResult = await exec.getExecOutput(
+                'git', ['apply', '--index', '--whitespace=fix'],
+                { ignoreReturnCode: true, input: Buffer.from(patch) }
+              );
+
+              if (applyResult.exitCode === 0) {
+                core.info(`Patch applied cleanly for ${branch}`);
+                await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
+                await exec.exec('git', ['push', 'origin', branch]);
+                core.info(`Pushed carried-forward changes to ${branch}`);
+              } else {
+                core.warning(`Patch did not apply cleanly for ${branch} — skipping to avoid broken state:\n${applyResult.stderr}`);
+                await exec.exec('git', ['apply', '--abort'], { ignoreReturnCode: true });
+              }
             }
           }
     - name: tag root major and minor versions

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -162,7 +162,7 @@ runs:
               core.info(`No automation changes to carry forward for ${branch}`);
             } else {
               const applyResult = await exec.getExecOutput(
-                'git', ['apply', '--index', '--whitespace=fix'],
+                'git', ['apply', '--3way', '--index', '--whitespace=fix'],
                 { ignoreReturnCode: true, input: Buffer.from(patch) }
               );
 
@@ -173,7 +173,8 @@ runs:
                 core.info(`Pushed carried-forward changes to ${branch}`);
               } else {
                 core.warning(`Patch did not apply cleanly for ${branch} — skipping to avoid broken state:\n${applyResult.stderr}`);
-                await exec.exec('git', ['apply', '--abort'], { ignoreReturnCode: true });
+                await exec.exec('git', ['checkout', '--', '.'], { ignoreReturnCode: true });
+                await exec.exec('git', ['reset', 'HEAD'], { ignoreReturnCode: true });
               }
             }
           }

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: false
   preserve_files:
-    description: 'Comma-separated list of file paths to carry forward after release-please force-pushes the release branch. Changes made on the old release branch (relative to its base) are merged into the new branch using a 3-way merge, so that only branch-specific edits (e.g. Argus image SHA tags) are preserved and changes merged into main are not reverted.'
+    description: 'File paths or glob patterns to carry forward after release-please force-pushes the release branch. Accepts comma-separated, newline-separated, or a mix of both. Globs (e.g. .infra/*/values.yaml) are expanded against the old branch tree. Changes are merged via 3-way merge so only branch-specific edits are preserved.'
     required: false
     default: ''
 runs:
@@ -19,15 +19,24 @@ runs:
     - name: snapshot release branch shas
       if: ${{ inputs.preserve_files != '' }}
       id: snapshot
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.app_token }}
-        REPO: ${{ github.repository }}
-      run: |
-        SHAS=$(gh api "repos/${REPO}/git/matching-refs/heads/release-please--branches--" \
-          --jq '[.[] | {(.ref | sub("refs/heads/"; "")): .object.sha}] | add // {}')
-        echo "branch_shas=${SHAS}" >> "$GITHUB_OUTPUT"
-        echo "Captured release-please branch SHAs: ${SHAS}"
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs.app_token }}
+        script: |
+          const { owner, repo } = context.repo;
+
+          const refs = await github.rest.git.listMatchingRefs({
+            owner,
+            repo,
+            ref: 'heads/release-please--branches--',
+          });
+          const branchShas = {};
+          for (const ref of refs.data) {
+            const branch = ref.ref.replace('refs/heads/', '');
+            branchShas[branch] = ref.object.sha;
+          }
+          core.info(`Captured release-please branch SHAs: ${JSON.stringify(branchShas)}`);
+          core.setOutput('branch_shas', JSON.stringify(branchShas));
     - name: release please
       uses: googleapis/release-please-action@v4
       id: release
@@ -36,96 +45,168 @@ runs:
         include-component-in-tag: ${{ inputs.include_component_in_tag }}
     - name: resolve release branch
       if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
-      id: resolve_branch
-      shell: bash
+      id: resolve_restore
+      uses: actions/github-script@v8
       env:
         BRANCH_SHAS: ${{ steps.snapshot.outputs.branch_shas }}
         PR_JSON: ${{ steps.release.outputs.pr }}
-      run: |
-        BRANCH=$(echo "$PR_JSON" | jq -r '.headBranchName')
-        if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
-          echo "Could not determine release branch name from pr output, skipping"
-          echo "should_restore=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+      with:
+        script: |
+          const branchShas = JSON.parse(process.env.BRANCH_SHAS || '{}');
+          let pr;
+          try {
+            pr = JSON.parse(process.env.PR_JSON);
+          } catch {
+            core.info('Could not parse PR output, skipping restore');
+            core.setOutput('should_restore', 'false');
+            return;
+          }
 
-        OLD_SHA=$(echo "$BRANCH_SHAS" | jq -r --arg b "$BRANCH" '.[$b] // empty')
-        if [ -z "$OLD_SHA" ]; then
-          echo "No previous SHA found for $BRANCH (new branch), skipping"
-          echo "should_restore=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+          const branch = pr.headBranchName;
+          if (!branch) {
+            core.info('Could not determine release branch name from pr output, skipping');
+            core.setOutput('should_restore', 'false');
+            return;
+          }
 
-        echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-        echo "old_sha=$OLD_SHA" >> "$GITHUB_OUTPUT"
-        echo "should_restore=true" >> "$GITHUB_OUTPUT"
+          const oldSha = branchShas[branch];
+          if (!oldSha) {
+            core.info(`No previous SHA found for ${branch} (new branch), skipping`);
+            core.setOutput('should_restore', 'false');
+            return;
+          }
+
+          core.info(`Branch: ${branch}, Old SHA: ${oldSha}`);
+          core.setOutput('branch', branch);
+          core.setOutput('old_sha', oldSha);
+          core.setOutput('should_restore', 'true');
     - name: checkout release branch
-      if: ${{ steps.resolve_branch.outputs.should_restore == 'true' }}
+      if: ${{ steps.resolve_restore.outputs.should_restore == 'true' }}
       uses: actions/checkout@v6
       with:
-        ref: ${{ steps.resolve_branch.outputs.branch }}
+        ref: ${{ steps.resolve_restore.outputs.branch }}
         token: ${{ inputs.app_token }}
         fetch-depth: 0
     - name: restore preserved files
-      if: ${{ steps.resolve_branch.outputs.should_restore == 'true' }}
-      shell: bash
+      if: ${{ steps.resolve_restore.outputs.should_restore == 'true' }}
+      uses: actions/github-script@v8
       env:
-        OLD_SHA: ${{ steps.resolve_branch.outputs.old_sha }}
-        BRANCH: ${{ steps.resolve_branch.outputs.branch }}
+        OLD_SHA: ${{ steps.resolve_restore.outputs.old_sha }}
+        BRANCH: ${{ steps.resolve_restore.outputs.branch }}
         PRESERVE_FILES: ${{ inputs.preserve_files }}
-      run: |
-        echo "Merging branch-specific changes from $OLD_SHA onto $BRANCH"
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const oldSha = process.env.OLD_SHA;
+          const branch = process.env.BRANCH;
+          const preserveFiles = process.env.PRESERVE_FILES;
 
-        git fetch origin "$OLD_SHA"
+          function globToRegex(pattern) {
+            const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+            return new RegExp('^' + escaped.replace(/\*/g, '[^/]*').replace(/\?/g, '.') + '$');
+          }
 
-        git config user.name "czi-github-helper[bot]"
-        git config user.email "95879977+czi-github-helper[bot]@users.noreply.github.com"
+          async function git(args, opts = {}) {
+            const result = await exec.getExecOutput('git', args, {
+              ignoreReturnCode: opts.ignoreReturnCode || false,
+              silent: opts.silent || false,
+            });
+            return result;
+          }
 
-        OLD_BASE=$(git merge-base "$OLD_SHA" HEAD)
-        echo "Old branch base (merge-base with current HEAD): $OLD_BASE"
+          core.info(`Merging branch-specific changes from ${oldSha} onto ${branch}`);
 
-        RESTORED=0
-        IFS=',' read -ra FILES <<< "$PRESERVE_FILES"
-        for file in "${FILES[@]}"; do
-          file=$(echo "$file" | xargs)
-          if [ -z "$file" ]; then
-            continue
-          fi
+          await exec.exec('git', ['fetch', 'origin', oldSha]);
+          await exec.exec('git', ['config', 'user.name', 'czi-github-helper[bot]']);
+          await exec.exec('git', ['config', 'user.email', '95879977+czi-github-helper[bot]@users.noreply.github.com']);
 
-          if ! git cat-file -e "${OLD_SHA}:${file}" 2>/dev/null; then
-            echo "File $file did not exist at $OLD_SHA, skipping"
-            continue
-          fi
+          const mergeBaseResult = await git(['merge-base', oldSha, 'HEAD']);
+          const oldBase = mergeBaseResult.stdout.trim();
+          core.info(`Old branch base (merge-base with current HEAD): ${oldBase}`);
 
-          if git diff --quiet "$OLD_BASE" "$OLD_SHA" -- "$file" 2>/dev/null; then
-            echo "File $file unchanged between old base and old branch tip, nothing to carry forward"
-            continue
-          fi
+          // Parse patterns: split on commas and newlines, trim
+          const patterns = preserveFiles
+            .split(/[,\n]/)
+            .map(s => s.trim())
+            .filter(Boolean);
 
-          git show "${OLD_BASE}:${file}" > "${file}.base" 2>/dev/null || true
-          git show "${OLD_SHA}:${file}" > "${file}.other"
-          cp "$file" "${file}.current"
+          // Get file tree at old SHA
+          const treeResult = await git(['ls-tree', '-r', '--name-only', oldSha]);
+          const allOldFiles = treeResult.stdout.trim().split('\n').filter(Boolean);
 
-          if git merge-file "${file}.current" "${file}.base" "${file}.other"; then
-            cp "${file}.current" "$file"
-            echo "3-way merged branch-specific changes for $file"
-          else
-            cp "${file}.current" "$file"
-            echo "WARNING: merge conflict in $file, applied with conflict markers — manual resolution may be needed"
-          fi
+          // Expand globs and deduplicate
+          const resolvedSet = new Set();
+          for (const pattern of patterns) {
+            const regex = globToRegex(pattern);
+            let matched = false;
+            for (const file of allOldFiles) {
+              if (regex.test(file)) {
+                resolvedSet.add(file);
+                matched = true;
+              }
+            }
+            if (!matched) {
+              core.info(`Pattern '${pattern}' matched no files at ${oldSha}, skipping`);
+            }
+          }
 
-          rm -f "${file}.base" "${file}.other" "${file}.current"
-          git add "$file"
-          RESTORED=$((RESTORED + 1))
-        done
+          const files = [...resolvedSet].sort();
+          core.info(`Resolved ${files.length} file(s) to check: ${files.join(', ')}`);
 
-        if [ "$RESTORED" -gt 0 ] && ! git diff --cached --quiet; then
-          git commit -m "release-please-preserve: carry forward branch-specific changes after release-please update"
-          git push origin "$BRANCH"
-          echo "Pushed $RESTORED file(s) with carried-forward changes to $BRANCH"
-        else
-          echo "No branch-specific changes needed carrying forward"
-        fi
+          let restored = 0;
+          for (const file of files) {
+            const diffResult = await git(
+              ['diff', '--quiet', oldBase, oldSha, '--', file],
+              { ignoreReturnCode: true }
+            );
+            if (diffResult.exitCode === 0) {
+              core.info(`File ${file} unchanged between old base and old branch tip, nothing to carry forward`);
+              continue;
+            }
+
+            const dir = path.dirname(file);
+            if (dir !== '.') {
+              fs.mkdirSync(dir, { recursive: true });
+            }
+
+            const baseResult = await git(['show', `${oldBase}:${file}`], { ignoreReturnCode: true });
+            fs.writeFileSync(`${file}.base`, baseResult.exitCode === 0 ? baseResult.stdout : '');
+
+            const otherResult = await git(['show', `${oldSha}:${file}`]);
+            fs.writeFileSync(`${file}.other`, otherResult.stdout);
+
+            const currentContent = fs.existsSync(file) ? fs.readFileSync(file) : Buffer.from('');
+            fs.writeFileSync(`${file}.current`, currentContent);
+
+            const mergeResult = await exec.getExecOutput(
+              'git', ['merge-file', `${file}.current`, `${file}.base`, `${file}.other`],
+              { ignoreReturnCode: true }
+            );
+
+            fs.copyFileSync(`${file}.current`, file);
+            if (mergeResult.exitCode === 0) {
+              core.info(`3-way merged branch-specific changes for ${file}`);
+            } else {
+              core.warning(`Merge conflict in ${file}, applied with conflict markers — manual resolution may be needed`);
+            }
+
+            fs.unlinkSync(`${file}.base`);
+            fs.unlinkSync(`${file}.other`);
+            fs.unlinkSync(`${file}.current`);
+
+            await exec.exec('git', ['add', file]);
+            restored++;
+          }
+
+          const diffCheck = await git(['diff', '--cached', '--quiet'], { ignoreReturnCode: true });
+          if (restored > 0 && diffCheck.exitCode !== 0) {
+            await exec.exec('git', ['commit', '-m', 'release-please-preserve: carry forward branch-specific changes after release-please update']);
+            await exec.exec('git', ['push', 'origin', branch]);
+            core.info(`Pushed ${restored} file(s) with carried-forward changes to ${branch}`);
+          } else {
+            core.info('No branch-specific changes needed carrying forward');
+          }
     - uses: actions/checkout@v6
       with:
           persist-credentials: true # used in subsequent action to git push


### PR DESCRIPTION
- Allows newline or comma (or a mix of both) separators in preserve_files
- Allows wildcards in preserve_files
- Makes it work when the job spawns multiple PRs, eg:
  - https://github.com/chanzuckerberg/argus-example-monorepo/pull/76
  - https://github.com/chanzuckerberg/argus-example-monorepo/pull/77
- Introduces a two-token approach where jobs with preserve_files specified push with a `GITHUB_TOKEN` that won't invoke workflows (a feature of Github tokens), then the restoration job force pushes over top of it with a token that can invoke workflows, preventing the errors caused by the second push killing Argus Docker builds invoked by the first and not re-invoking them