### PR TITLE
fix: allow release creation to trigger workflows

### DIFF
--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -37,6 +37,11 @@ runs:
           }
           core.info(`Captured release-please branch SHAs: ${JSON.stringify(branchShas)}`);
           core.setOutput('branch_shas', JSON.stringify(branchShas));
+    # Creates/updates the release PR branch only. Uses GITHUB_TOKEN when preserve_files
+    # is set so this push is silent (GITHUB_TOKEN pushes never trigger workflow runs).
+    # The restore/trigger steps below re-push with app_token so path-filtered workflows
+    # fire exactly once with the complete changeset. When preserve_files is not set,
+    # app_token is used directly and no re-push is needed.
     - name: release please (PR)
       uses: googleapis/release-please-action@v4
       id: release_pr
@@ -44,6 +49,8 @@ runs:
         token: ${{ inputs.preserve_files != '' && github.token || inputs.app_token }}
         include-component-in-tag: ${{ inputs.include_component_in_tag }}
         skip-github-release: true
+    # Creates the GitHub release and tags when the release PR is merged. Always uses
+    # app_token so the resulting release event triggers downstream on:release workflows.
     - name: release please (release)
       uses: googleapis/release-please-action@v4
       id: release

--- a/.github/actions/release-please-semvar/action.yml
+++ b/.github/actions/release-please-semvar/action.yml
@@ -37,19 +37,27 @@ runs:
           }
           core.info(`Captured release-please branch SHAs: ${JSON.stringify(branchShas)}`);
           core.setOutput('branch_shas', JSON.stringify(branchShas));
-    - name: release please
+    - name: release please (PR)
       uses: googleapis/release-please-action@v4
-      id: release
+      id: release_pr
       with:
         token: ${{ inputs.preserve_files != '' && github.token || inputs.app_token }}
         include-component-in-tag: ${{ inputs.include_component_in_tag }}
+        skip-github-release: true
+    - name: release please (release)
+      uses: googleapis/release-please-action@v4
+      id: release
+      with:
+        token: ${{ inputs.app_token }}
+        include-component-in-tag: ${{ inputs.include_component_in_tag }}
+        skip-github-pull-request: true
     - name: resolve release branches
-      if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
+      if: ${{ steps.release_pr.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
       id: resolve_restore
       uses: actions/github-script@v8
       env:
         BRANCH_SHAS: ${{ steps.snapshot.outputs.branch_shas }}
-        PRS_JSON: ${{ steps.release.outputs.prs }}
+        PRS_JSON: ${{ steps.release_pr.outputs.prs }}
       with:
         script: |
           const branchShas = JSON.parse(process.env.BRANCH_SHAS || '{}');
@@ -250,10 +258,10 @@ runs:
           core.setOutput('pushed_branches', JSON.stringify(pushedBranches));
     - name: trigger workflows on release branches without restore
       id: trigger_workflows
-      if: ${{ steps.release.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
+      if: ${{ steps.release_pr.outputs.prs_created == 'true' && inputs.preserve_files != '' }}
       uses: actions/github-script@v8
       env:
-        PRS_JSON: ${{ steps.release.outputs.prs }}
+        PRS_JSON: ${{ steps.release_pr.outputs.prs }}
         PUSHED_BRANCHES: ${{ steps.restore_preserved_files.outputs.pushed_branches }}
       with:
         script: |


### PR DESCRIPTION
## Split release-please into two steps

Previously a single `googleapis/release-please-action@v4` call handled both PR creation and release creation. When `preserve_files` is set, the action uses `GITHUB_TOKEN` to silence the branch push — but this also silenced release creation, breaking `on: release` downstream workflows.

The fix splits the action into two calls:

- **`release_pr`** (`skip-github-release: true`) — handles PR branch creation/update only, uses the silent token strategy when needed
- **`release`** (`skip-github-pull-request: true`) — handles GitHub release creation only, always uses `app_token` so release events trigger downstream workflows

PR-related output references (`prs_created`, `prs`) now come from `steps.release_pr.outputs`; release-related references (`release_created`, `major`, `minor`) remain on `steps.release.outputs`.