### PR TITLE
feat: pass platform from matrix to docker-build action

### DIFF
--- a/.github/workflows/argus-builder-dispatch.yaml
+++ b/.github/workflows/argus-builder-dispatch.yaml
@@ -190,6 +190,7 @@ jobs:
           image_name: ${{ matrix.image.name }}
           dockerfile: ${{ matrix.image.dockerfile }}
           context: ${{ matrix.image.context }}
+          platform: ${{ matrix.image.platform }}
           build_args: ${{ matrix.image.build_args }}
           secret_files: ${{ steps.secrets.outputs.secret_files }}
           image_tag: ${{ matrix.image.tag }}


### PR DESCRIPTION
Thread the per-image platform field through the build matrix so docker buildx uses the correct --platform flag. The runner is still selected by the caller via default_runner_labels, meaning cross-architecture builds may occur