### PR TITLE
feat(terragrunt-engine): add versioned release-please package for engine workflow

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,5 +15,6 @@
 	".github/actions/find-changed-terragrunt-stacks": "0.1.0",
 	".github/actions/install-aws-cli": "0.1.0",
 	".github/actions/release-terraform-locks": "0.1.0",
-	".github/actions/terragrunt-provider-cache": "0.1.0"
+	".github/actions/terragrunt-provider-cache": "0.1.0",
+	".github/workflows/terragrunt-engine": "0.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -72,6 +72,9 @@
 		".github/actions/terragrunt-provider-cache": {
 			"package-name": "terragrunt-provider-cache"
 		},
+		".github/workflows/terragrunt-engine": {
+			"package-name": "terragrunt-engine"
+		},
 		".": {}
 	}
 }


### PR DESCRIPTION
## Overview

The five composite actions added in #549 each got their own release-please package and are now versioned independently (e.g. \`install-aws-cli-v0\`). The reusable \`terragrunt-engine.yml\` workflow was left without its own package, meaning callers had to pin to the root \`v6.25.0\` tag — which covers all repo changes, not just the engine.

## Solution

Register \`.github/workflows/terragrunt-engine\` as an independent release-please package with \`package-name: "terragrunt-engine"\`. The scoped \`feat(terragrunt-engine):\` commit title ensures release-please attributes the bump to this package and generates \`terragrunt-engine-v0.1.0\` / \`terragrunt-engine-v0\` tags on merge.

## Impact

Callers of the engine workflow (starting with argus-infra-stacks #2573) can pin to \`@terragrunt-engine-v0\` and get the floating major-version tag, consistent with how the composite actions are referenced.