### PR TITLE
fix(terragrunt-engine): bump get-github-ref-names to v1 for workflow_dispatch support

### DIFF
--- a/.github/workflows/terragrunt-engine.yml
+++ b/.github/workflows/terragrunt-engine.yml
@@ -144,7 +144,7 @@ jobs:
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
       - name: Get Base Git Ref
         id: ref
-        uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1.6.0
+        uses: chanzuckerberg/github-actions/.github/actions/get-github-ref-names@get-github-ref-names-v1
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

Manual `Terragrunt Apply All` runs (triggered via `workflow_dispatch`) fail immediately at the **Get Base Git Ref** step with `EventName workflow_dispatch not supported`. Because that step calls `core.setFailed`, the job halts before checkout, which cascades into spurious AWS credential retry failures and a `stack root is not a directory` error. None of it is real infrastructure breakage — the job never gets off the ground.

## Solution

The engine pinned `get-github-ref-names` at `v1.6.0`, which predates the `workflow_dispatch`/`repository_dispatch` support added to that action (released as `v1.7`/`v1.8`). This bumps the reference to the floating major tag `get-github-ref-names-v1`, matching the floating-major convention used by the other action references in this workflow. The action now resolves the head ref from `github.ref_name` and the base from the default branch for dispatch events, so manual runs proceed through checkout and the rest of the pipeline.

## Impact

Manual `workflow_dispatch` invocations of the terragrunt engine work again. Pull request and push triggers are unaffected.