### PR TITLE
fix(get-github-ref-names): support schedule event

### DIFF
--- a/.github/actions/get-github-ref-names/action.yml
+++ b/.github/actions/get-github-ref-names/action.yml
@@ -47,6 +47,11 @@ runs:
             // default branch for base.
             head = context.ref.replace(/^refs\/(heads|tags)\//, "");
             base = context.payload.repository.default_branch;
+          } else if (eventName === "schedule") {
+            // Scheduled runs have no branch context beyond the default branch,
+            // so point both refs at it.
+            head = context.payload.repository.default_branch;
+            base = context.payload.repository.default_branch;
           } else {
             core.setFailed(`EventName ${eventName} not supported`);
             return;


### PR DESCRIPTION
## Problem

The nightly `Terragrunt Apply All` cron in argus-infra-stacks (and any repo running the terragrunt-engine on a schedule) fails immediately at the `Get Base Git Ref` step with `EventName schedule not supported`. The `get-github-ref-names` action only handles `pull_request`, `push`, `delete`, `release`, and the dispatch events. A `schedule` trigger falls through to the catch-all branch, which calls `core.setFailed`, killing the job before Terragrunt ever runs. Manual `workflow_dispatch` runs are fine, so only the scheduled nightly is broken.

## Solution

Handle the `schedule` event the same way as `release`: a scheduled run has no branch context beyond the default branch, so both the head and base refs point at the repository default branch. The engine then checks out the default branch for the nightly run, which is exactly what an unattended apply-all wants.

## Impact

Restores scheduled terragrunt-engine runs for every consuming repo. Once released, the floating `get-github-ref-names-v1` tag moves to this commit, so callers pinned to `-v1` (including the engine) pick it up with no further change.