### PR TITLE
fix(terragrunt-engine): run set-apply-gate even when no stacks changed

### DIFF
--- a/.github/workflows/terragrunt-engine.yml
+++ b/.github/workflows/terragrunt-engine.yml
@@ -188,8 +188,7 @@ jobs:
       !cancelled() &&
       inputs.set_apply_gate &&
       (needs.validate-comment.result == 'success' || needs.validate-comment.result == 'skipped') &&
-      needs.find-changed-stacks.result == 'success' &&
-      needs.find-changed-stacks.outputs.stacks != '[]'
+      needs.find-changed-stacks.result == 'success'
     timeout-minutes: 5
     steps:
       - name: Generate token


### PR DESCRIPTION
## Overview

PRs that don't touch terraform files fail to merge because the required `terragrunt-apply` status is never posted.

## Solution

Removed the `stacks != '[]'` condition from the `set-apply-gate` job. The `gate` function already handles the empty case by posting a success status with "No Terraform stacks changed", so the condition was just preventing it from running.

## Impact

Docs-only and workflow-only PRs now get the required status posted automatically instead of hanging with a missing check.

## References

- Follow-up to #585