### PR TITLE
fix(argus-builder): push only Argus-computed tags to avoid env image collision

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -149,12 +149,13 @@ runs:
         custom_tag: |
           ${{ inputs.image_tag }}
           ${{ inputs.additional_tags }}
-        # Argus computes the complete tag set (image_tag + additional_tags,
-        # including env-specific sha-<sha>-<env> tags). The built-in metadata
-        # rules would also stamp an unsuffixed sha-<sha> tag on every build,
-        # which makes env-specific builds (rdev/staging) overwrite the default
-        # image in the shared ECR repo. Push only the tags Argus provides.
-        disable_default_tags: "true"
+        # Argus supplies its own SHA-based tags via image_tag/additional_tags
+        # (including env-specific sha-<sha>-<env> tags). Suppress the built-in
+        # type=sha tags, which are env-agnostic (sha-<sha>) and would make
+        # env-specific builds (rdev/staging) overwrite the default image in the
+        # shared ECR repo. Other metadata rules (branch-/pr-/semver) are left
+        # intact but don't fire on the orchestrator's workflow_dispatch builds.
+        disable_sha_tags: "true"
         platforms: ${{ inputs.platform }}
         build_args: |
           IMAGE_TAG=${{ inputs.image_tag }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -149,6 +149,12 @@ runs:
         custom_tag: |
           ${{ inputs.image_tag }}
           ${{ inputs.additional_tags }}
+        # Argus computes the complete tag set (image_tag + additional_tags,
+        # including env-specific sha-<sha>-<env> tags). The built-in metadata
+        # rules would also stamp an unsuffixed sha-<sha> tag on every build,
+        # which makes env-specific builds (rdev/staging) overwrite the default
+        # image in the shared ECR repo. Push only the tags Argus provides.
+        disable_default_tags: "true"
         platforms: ${{ inputs.platform }}
         build_args: |
           IMAGE_TAG=${{ inputs.image_tag }}

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -22,13 +22,15 @@ inputs:
     description: "Tag(s) to apply to the built image. If you supply a multi-line string, each line will be applied as a tag."
     required: false
     default: ""
-  disable_default_tags:
+  disable_sha_tags:
     description: >-
-      When "true", skip the built-in metadata-action tag rules (branch-, pr-,
-      semver, and sha-/sha-long) and push ONLY the tags supplied via custom_tag.
-      Use this when the caller computes the complete tag set itself (e.g. the
-      Argus builder, which derives env-specific sha tags) and must not have an
-      unsuffixed sha- tag auto-added.
+      When "true", skip the built-in commit-SHA tag rules (type=sha short and
+      long, both prefixed with sha-). All other built-in rules (branch-, pr-,
+      semver) and custom_tag are unaffected. Use this when the caller supplies
+      its own SHA-based tags via custom_tag (e.g. the Argus builder, which
+      derives env-specific sha-<sha>-<env> tags) and must not have an
+      env-agnostic sha- tag auto-added that would overwrite a sibling image in
+      a shared repository.
     required: false
     default: "false"
   secret-files:
@@ -86,15 +88,15 @@ runs:
       id: tag_rules
       shell: bash
       env:
-        DISABLE_DEFAULT_TAGS: ${{ inputs.disable_default_tags }}
+        DISABLE_SHA_TAGS: ${{ inputs.disable_sha_tags }}
         CUSTOM_TAG: ${{ inputs.custom_tag }}
       run: |
         tags=""
-        if [ "${DISABLE_DEFAULT_TAGS}" != "true" ]; then
-          tags+="type=ref,event=branch,prefix=branch-"$'\n'
-          tags+="type=ref,event=pr,prefix=pr-"$'\n'
-          tags+="type=semver,pattern={{version}}"$'\n'
-          tags+="type=semver,pattern={{major}}.{{minor}}"$'\n'
+        tags+="type=ref,event=branch,prefix=branch-"$'\n'
+        tags+="type=ref,event=pr,prefix=pr-"$'\n'
+        tags+="type=semver,pattern={{version}}"$'\n'
+        tags+="type=semver,pattern={{major}}.{{minor}}"$'\n'
+        if [ "${DISABLE_SHA_TAGS}" != "true" ]; then
           tags+="type=sha,prefix=sha-"$'\n'
           tags+="type=sha,format=long,prefix=sha-"$'\n'
         fi

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -22,6 +22,15 @@ inputs:
     description: "Tag(s) to apply to the built image. If you supply a multi-line string, each line will be applied as a tag."
     required: false
     default: ""
+  disable_default_tags:
+    description: >-
+      When "true", skip the built-in metadata-action tag rules (branch-, pr-,
+      semver, and sha-/sha-long) and push ONLY the tags supplied via custom_tag.
+      Use this when the caller computes the complete tag set itself (e.g. the
+      Argus builder, which derives env-specific sha tags) and must not have an
+      unsuffixed sha- tag auto-added.
+    required: false
+    default: "false"
   secret-files:
     description: "A list of files to be copied into the build context."
     required: false
@@ -73,19 +82,34 @@ runs:
       with:
         driver-opts: |
           image=533267185808.dkr.ecr.us-west-2.amazonaws.com/docker.io/central/moby/buildkit:v0.25.0
+    - name: Compute metadata tag rules
+      id: tag_rules
+      shell: bash
+      env:
+        DISABLE_DEFAULT_TAGS: ${{ inputs.disable_default_tags }}
+        CUSTOM_TAG: ${{ inputs.custom_tag }}
+      run: |
+        tags=""
+        if [ "${DISABLE_DEFAULT_TAGS}" != "true" ]; then
+          tags+="type=ref,event=branch,prefix=branch-"$'\n'
+          tags+="type=ref,event=pr,prefix=pr-"$'\n'
+          tags+="type=semver,pattern={{version}}"$'\n'
+          tags+="type=semver,pattern={{major}}.{{minor}}"$'\n'
+          tags+="type=sha,prefix=sha-"$'\n'
+          tags+="type=sha,format=long,prefix=sha-"$'\n'
+        fi
+        tags+="${CUSTOM_TAG}"
+        {
+          echo "tags<<__TAG_RULES_EOF__"
+          printf '%s\n' "$tags"
+          echo "__TAG_RULES_EOF__"
+        } >> "$GITHUB_OUTPUT"
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v6
       with:
         images: ${{ inputs.registry }}/${{ inputs.name }}
-        tags: |
-          type=ref,event=branch,prefix=branch-
-          type=ref,event=pr,prefix=pr-
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix=sha-
-          type=sha,format=long,prefix=sha-
-          ${{ inputs.custom_tag }}
+        tags: ${{ steps.tag_rules.outputs.tags }}
     - name: Login to ECR
       uses: docker/login-action@v4
       with:


### PR DESCRIPTION
## Summary

The shared `docker-build-push` action hardcoded `docker/metadata-action` tag rules, including `type=sha,prefix=sha-` and `type=sha,format=long,prefix=sha-`. These stamp **env-agnostic** `sha-<sha>` / `sha-<full40>` tags on every build, independent of `custom_tag`.

For Argus **env-specific** builds (e.g. `rdev`), the ECR repo is keyed only by `context` + `image_name`, and env overrides typically change only `build_args` — so the `rdev` variant shares the same ECR repo as the default (prod) image. The auto-added bare `sha-<sha>` tags therefore **overwrote the prod image** in the shared repo, instead of only pushing the intended `sha-<sha>-rdev` tag. This caused a real prod/rdev image collision.

## Changes

- **`docker-build-push`**: new `disable_sha_tags` input (default `"false"`, so all existing callers are unchanged). When `"true"`, only the two `type=sha` rules are skipped; `branch-`, `pr-`, `semver`, and `custom_tag` are left intact. Implemented via a small `Compute metadata tag rules` step feeding `metadata-action`.
- **`argus-builder/docker-build`**: opts in (`disable_sha_tags: "true"`), since Argus already supplies the full SHA-based tag set via `image_tag` + `additional_tags` (including env-specific `sha-<sha>-<env>` tags).

## Why only the `type=sha` rules

Only the `type=sha` rules are env-agnostic and thus collide across sibling builds in a shared repo — both the short and long variants. The `branch-`/`pr-`/`semver` rules are left untouched to minimize blast radius for other callers; in the Argus path they don't fire anyway, since the builder runs via `workflow_dispatch` (those rules only emit on push/PR/tag events).

## Effect

- rdev/staging (env-override) builds push only `sha-<sha>-<env>` — no more bare `sha-<sha>` collision with prod.
- default/prod builds are unchanged (they still push `sha-<sha>` via `image_tag` plus any `additional_tags`).
- Non-Argus consumers of `docker-build-push` are unaffected (default `disable_sha_tags: "false"`).
- Branch-based layer caching is unaffected: `cache-from`/`cache-to` use separate `cache-branch-*` registry refs, not the pushed image tags.

## Test plan

- [ ] Trigger an Argus build with an env override (e.g. evolutionaryscale `biohub-platform`/`metagenomic-atlas` frontend) and confirm the rdev job pushes only `sha-<sha>-rdev`, and the default job pushes `sha-<sha>` (+ any additional tags).
- [ ] Confirm a non-Argus caller of `docker-build-push` still gets the branch-/pr-/semver-/sha- tags.
- [ ] Release/bump the `v6` tag so consumers (`argus-builder-dispatch.yaml`, downstream repos pinned to `@v6`) pick up the fix.