### PR TITLE
fix(argus-builder): build the resolved commit (use commit_sha as checkout ref)

### DIFF
--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -31,15 +31,10 @@ inputs:
     required: false
     default: ""
   commit_sha:
-    description: "Full commit SHA passed as COMMIT_SHA build arg"
-    required: false
-    default: ""
-  ref:
     description: >-
-      Git ref or SHA to check out and build. Should be the same commit the
-      caller derived image_tag from, so the built source, the image tag, and
-      the COMMIT_SHA build arg all reference one commit. Defaults to the
-      workflow's github.sha when empty.
+      Full commit SHA to build. Used both as the checkout ref (so the built
+      source matches the commit the caller derived image_tag from) and as the
+      COMMIT_SHA build arg. Defaults to the workflow's github.sha when empty.
     required: false
     default: ""
   github_app_id:
@@ -83,7 +78,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ inputs.ref }}
+        ref: ${{ inputs.commit_sha }}
         clean: ${{ inputs.clean_checkout }}
         fetch-depth: 1
         path: ${{ github.event.repository.name }}

--- a/.github/actions/argus-builder/docker-build/action.yml
+++ b/.github/actions/argus-builder/docker-build/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Full commit SHA passed as COMMIT_SHA build arg"
     required: false
     default: ""
+  ref:
+    description: >-
+      Git ref or SHA to check out and build. Should be the same commit the
+      caller derived image_tag from, so the built source, the image tag, and
+      the COMMIT_SHA build arg all reference one commit. Defaults to the
+      workflow's github.sha when empty.
+    required: false
+    default: ""
   github_app_id:
     description: "GitHub App ID"
     required: true
@@ -75,6 +83,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
       with:
+        ref: ${{ inputs.ref }}
         clean: ${{ inputs.clean_checkout }}
         fetch-depth: 1
         path: ${{ github.event.repository.name }}

--- a/.github/workflows/argus-builder-dispatch.yaml
+++ b/.github/workflows/argus-builder-dispatch.yaml
@@ -196,6 +196,12 @@ jobs:
           image_tag: ${{ matrix.image.tag }}
           additional_tags: ${{ matrix.image.additional_tags }}
           commit_sha: ${{ needs.resolve.outputs.trigger_sha }}
+          # Build the exact commit the resolve job pinned (and tagged from), not
+          # the branch tip. On a re-run after the branch advanced, the default
+          # github.sha checkout would build a different commit than image_tag
+          # reflects; pinning to trigger_sha keeps source, tag, and COMMIT_SHA
+          # consistent.
+          ref: ${{ needs.resolve.outputs.trigger_sha }}
           compression: ${{ matrix.image.compression }}
           compression_level: ${{ matrix.image.compression_level }}
           force_compression: ${{ matrix.image.force_compression }}

--- a/.github/workflows/argus-builder-dispatch.yaml
+++ b/.github/workflows/argus-builder-dispatch.yaml
@@ -195,13 +195,10 @@ jobs:
           secret_files: ${{ steps.secrets.outputs.secret_files }}
           image_tag: ${{ matrix.image.tag }}
           additional_tags: ${{ matrix.image.additional_tags }}
+          # trigger_sha is the commit the resolve job pinned and derived
+          # image_tag from. docker-build checks this out (not the branch tip),
+          # so source, image tag, and COMMIT_SHA stay consistent across re-runs.
           commit_sha: ${{ needs.resolve.outputs.trigger_sha }}
-          # Build the exact commit the resolve job pinned (and tagged from), not
-          # the branch tip. On a re-run after the branch advanced, the default
-          # github.sha checkout would build a different commit than image_tag
-          # reflects; pinning to trigger_sha keeps source, tag, and COMMIT_SHA
-          # consistent.
-          ref: ${{ needs.resolve.outputs.trigger_sha }}
           compression: ${{ matrix.image.compression }}
           compression_level: ${{ matrix.image.compression_level }}
           force_compression: ${{ matrix.image.force_compression }}


### PR DESCRIPTION
## Summary

The Argus builder's `resolve` job derives `image_tag` and `trigger_sha` from `inputs.ref` (the branch), but the matrix `build` job's `docker-build` checkout specified **no ref**, so it fell back to the run's pinned `github.sha`. These agree on the first attempt (branch tip == `github.sha`), but **diverge on a re-run after the branch advanced**: the image is built from `github.sha` yet tagged `sha-<newsha>[-env]` with `COMMIT_SHA=<newsha>` — the artifact's content and its tag/label disagree.

Observed on `runs/30963940694` attempt #3: the build checked out `71b622c` (original `github.sha`) but pushed `sha-313b207-rdev` with `COMMIT_SHA=313b207`.

## Change

`commit_sha` already carries the resolved `trigger_sha` into the build job (used as the `COMMIT_SHA` build arg). Rather than add a redundant input, `docker-build` now also uses `commit_sha` as its checkout ref. When empty it falls back to `github.sha`, so behavior is unchanged for callers that don't set it.

This structurally enforces the invariant that the commit we build == the commit we stamp as `COMMIT_SHA` == the commit `image_tag` was derived from.

## Effect

- On re-runs (or any time the branch moved since dispatch), the build now checks out the exact commit `resolve` pinned, so source, `image_tag`, and `COMMIT_SHA` stay consistent.
- No new inputs; single-line behavior change plus doc update.

## Notes

- This is the in-workflow fix. A complementary orchestrator-side change (dispatching with a pinned commit SHA as `inputs.ref` instead of the branch) would additionally make re-runs reproducible across attempts; not required for this consistency fix.
- Secret-file materialization (`materialize-secret-files`, for `path`-type secrets) checks out via its own path and is out of scope here; worth a follow-up if any app uses `path` secret files whose contents change between attempts.

## Test plan

- [ ] Dispatch an Argus build; confirm the build job checks out `commit_sha` (matches `image_tag`/`COMMIT_SHA`).
- [ ] Re-run a build after pushing a new commit to the branch; confirm the built commit == the tagged commit (no divergence).
- [ ] Release/bump `v6` so consumers pick up the change.